### PR TITLE
feat: globo esférico como landing page con mapgl

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -6,7 +6,7 @@ library(yaml)
 library(DT)
 library(bslib)
 library(shinyWidgets)
-library(leaflet)
+library(mapgl)
 library(sf)
 library(rnaturalearth)
 library(rnaturalearthdata)
@@ -37,27 +37,35 @@ leer_paquetes <- function() {
 
 paquetes <- leer_paquetes()
 
-# Preparar datos del mapa: conteo de paquetes por país + shapes de rnaturalearth
-preparar_datos_mapa <- function(paquetes_df) {
-  conteo <- paquetes_df %>%
-    filter(!is.na(pais), pais != "No especificado") %>%
-    count(pais, name = "n_paquetes")
-  
-  # Shapes de países de las Américas
-  sudamerica <- ne_countries(continent = "South America", returnclass = "sf")
-  norteamerica <- ne_countries(continent = "North America", returnclass = "sf")
-  shapes <- rbind(sudamerica, norteamerica)
-  
-  # Merge conteo con shapes (name_en coincide con nuestros valores de pais)
-  shapes <- shapes %>%
-    left_join(conteo, by = c("name_en" = "pais")) %>%
-    mutate(n_paquetes = ifelse(is.na(n_paquetes), 0, n_paquetes))
-  
-  shapes
-}
+# --- Preparar datos del globo: puntos por país con cantidad de paquetes ---
 
-shapes_mapa <- preparar_datos_mapa(paquetes)
-max_paquetes <- max(shapes_mapa$n_paquetes, na.rm = TRUE)
+# Coordenadas aproximadas de capital de cada país
+coords_paises <- tibble(
+  pais = c("Argentina","Bolivia","Brazil","Chile","Colombia","Costa Rica",
+           "Cuba","Ecuador","El Salvador","Guatemala","Honduras","Mexico",
+           "Nicaragua","Panama","Paraguay","Peru","Puerto Rico",
+           "Dominican Republic","Uruguay","Venezuela"),
+  lon = c(-63.6,-67.0,-51.9,-71.5,-74.0,-84.0,
+          -77.8,-78.5,-89.2,-90.2,-87.2,-102.6,
+          -85.2,-80.8,-57.7,-75.0,-66.6,
+          -69.0,-55.8,-66.6),
+  lat = c(-35.4,-16.3,-14.2,-35.0,4.6,10.0,
+          21.5,-1.5,13.7,15.8,14.6,23.6,
+          12.9,8.5,-23.4,-9.2,18.2,
+          18.7,-32.5,6.0)
+)
+
+# Contar paquetes por país
+conteo_paises <- paquetes %>%
+  filter(!is.na(pais), pais != "No especificado") %>%
+  count(pais, name = "n_paquetes")
+
+# SF de puntos con conteo
+puntos_mapa <- coords_paises %>%
+  left_join(conteo_paises, by = "pais") %>%
+  mutate(n_paquetes = ifelse(is.na(n_paquetes), 0, n_paquetes)) %>%
+  filter(n_paquetes > 0) %>%
+  st_as_sf(coords = c("lon","lat"), crs = 4326, remove = FALSE)
 
 # Mapeo país (nombre en español) -> código ISO 3166-1 alpha-2 para banderas
 pais_iso <- c(
@@ -131,7 +139,7 @@ ui <- page_fluid(
       /* === Hero === */
       .hero-section {
         background: #FFFFFF;
-        padding: 3rem 0 2rem 0;
+        padding: 2rem 0 1.5rem 0;
         border-bottom: 3px solid #151515;
         margin-bottom: 0;
         border-radius: 0;
@@ -293,6 +301,23 @@ ui <- page_fluid(
       }
       .package-card { animation: fadeInUp 0.4s ease-out; }
       html { scroll-behavior: smooth; }
+      /* === Landing / globo === */
+      .landing-wrap {
+        padding: 2rem 0 3rem 0;
+      }
+      .landing-cta {
+        text-align: center;
+        margin-top: 2rem;
+      }
+      .landing-cta .btn {
+        margin: 0 0.5rem 0.5rem 0.5rem;
+      }
+      /* === Mapa container === */
+      .map-container {
+        border: 2px solid #151515;
+        box-shadow: 6px 6px 0 #EAFF38;
+        margin-top: 1.5rem;
+      }
     "))
   ),
 
@@ -305,7 +330,6 @@ ui <- page_fluid(
         class = "row",
         div(
           class = "col-md-12 text-center",
-          # Logo de Estación R
           tags$img(
             src = "img/logo_estacion_r_ancho.png",
             alt = "Estación R",
@@ -323,52 +347,84 @@ ui <- page_fluid(
     )
   ),
 
-  # Contenedor principal con tabs
+  # Contenedor principal con tabs: Mapa primero (landing), Catálogo después
   div(
     class = "container",
     style = "margin-top: -20px;",
 
     navset_card_tab(
       id = "tab_principal",
+      selected = "tab_mapa",
+
+      # --- Tab Mapa (landing page) ---
+      nav_panel(
+        title = icon("globe", " Mapa"),
+        value = "tab_mapa",
+
+        div(
+          class = "landing-wrap",
+
+          # Stats compactas arriba del globo
+          fluidRow(
+            column(
+              4,
+              div(
+                class = "stats-card",
+                icon("cube", style = "font-size: 2rem; color: #447099;"),
+                div(class = "stats-number", textOutput("total_paquetes", inline = TRUE)),
+                div(class = "stats-label", "Paquetes")
+              )
+            ),
+            column(
+              4,
+              div(
+                class = "stats-card",
+                icon("globe-americas", style = "font-size: 2rem; color: #72994E;"),
+                div(class = "stats-number", textOutput("total_paises", inline = TRUE)),
+                div(class = "stats-label", "Países")
+              )
+            ),
+            column(
+              4,
+              div(
+                class = "stats-card",
+                icon("folder-open", style = "font-size: 2rem; color: #419599;"),
+                div(class = "stats-number", textOutput("total_categorias", inline = TRUE)),
+                div(class = "stats-label", "Categorías")
+              )
+            )
+          ),
+
+          # Globo esférico
+          div(
+            class = "map-container",
+            maplibreOutput("mapa_globo", height = "550px")
+          ),
+
+          # CTA para entrar al catálogo
+          div(
+            class = "landing-cta",
+            p(style = "color: #707073; margin-bottom: 1rem;",
+              "Hacé clic en un país para ver sus paquetes · o explorá el catálogo completo"),
+            actionButton(
+              inputId = "ir_catalogo",
+              label = "Ver todos los paquetes",
+              icon = icon("list"),
+              class = "btn-estacion"
+            )
+          )
+        )
+      ),
+
+      # --- Tab Catálogo ---
       nav_panel(
         title = icon("list", " Catálogo"),
         value = "tab_catalogo",
 
-        # Estadísticas generales
-        fluidRow(
-          column(
-            4,
-            div(
-              class = "stats-card",
-              icon("cube", style = "font-size: 2rem; color: #447099;"),
-              div(class = "stats-number", textOutput("total_paquetes", inline = TRUE)),
-              div(class = "stats-label", "Paquetes")
-            )
-          ),
-          column(
-            4,
-            div(
-              class = "stats-card",
-              icon("globe-americas", style = "font-size: 2rem; color: #72994E;"),
-              div(class = "stats-number", textOutput("total_paises", inline = TRUE)),
-              div(class = "stats-label", "Países")
-            )
-          ),
-          column(
-            4,
-            div(
-              class = "stats-card",
-              icon("folder-open", style = "font-size: 2rem; color: #419599;"),
-              div(class = "stats-number", textOutput("total_categorias", inline = TRUE)),
-              div(class = "stats-label", "Categorías")
-            )
-          )
-        ),
-
         # Filtros
         div(
           class = "filter-card",
-          style = "margin-top: 30px;",
+          style = "margin-top: 20px;",
           h4(icon("filter"), " Filtrar Paquetes", style = "margin-bottom: 20px; color: #447099;"),
           fluidRow(
             column(
@@ -425,49 +481,12 @@ ui <- page_fluid(
           uiOutput("resultados_info"),
           uiOutput("lista_paquetes")
         )
-      ),
-
-      nav_panel(
-        title = icon("map", " Mapa"),
-        value = "tab_mapa",
-
-        # Header del mapa
-        div(
-          style = "margin-bottom: 20px;",
-          # Output oculto para que conditionalPanel pueda evaluar la condición
-          textOutput("mapa_hay_seleccion", inline = TRUE),
-          tags$style("#mapa_hay_seleccion{display: none;}"),
-          h4(icon("globe-americas"), " Paquetes por país", style = "color: #447099; margin-bottom: 10px;"),
-          p(style = "color: #6c757d;", "Hacé clic en un país para filtrar el catálogo."),
-          conditionalPanel(
-            condition = "output.mapa_hay_seleccion",
-            div(
-              style = "margin-top: 10px; padding: 10px 15px; background: #f8f9fa; border-radius: 8px; border-left: 4px solid #447099;",
-              uiOutput("mapa_pais_seleccionado")
-            )
-          )
-        ),
-
-        # Mapa leaflet
-        leafletOutput("mapa_paquetes", height = "500px"),
-
-        # Botón para limpiar filtro del mapa
-        div(
-          style = "text-align: center; margin-top: 15px;",
-          actionButton(
-            inputId = "limpiar_mapa",
-            label = "Mostrar todos los países",
-            icon = icon("eraser"),
-            class = "btn-outline-secondary btn-sm"
-          )
-        )
       )
     ),
 
     # Footer
     div(
       class = "footer-brand",
-      # Logo de Estación R
       tags$img(
         src = "img/logo_estacion_r_ancho.png",
         alt = "Estación R",
@@ -507,7 +526,7 @@ server <- function(input, output, session) {
   if (is.null(paquetes)) {
     showModal(modalDialog(
       title = "Error al cargar datos",
-      "No se pudieron cargar los paquetes desde Google Sheets. Por favor, intenta más tarde.",
+      "No se pudieron cargar los paquetes. Por favor, intenta más tarde.",
       easyClose = TRUE,
       footer = NULL
     ))
@@ -532,75 +551,55 @@ server <- function(input, output, session) {
     updateSearchInput(session, "busqueda", value = "")
   })
 
-  # --- Mapa interactivo ---
+  # --- Globo esférico (landing page) ---
 
-  # Flag para mostrar/ocultar info del país seleccionado en el mapa
-  mapa_pais_sel <- reactiveVal(NULL)
+  output$mapa_globo <- renderMaplibre({
+    req(puntos_mapa)
 
-  # Output auxiliar para conditionalPanel (debe ser textOutput inline)
-  output$mapa_hay_seleccion <- renderText({
-    if (is.null(mapa_pais_sel())) "false" else "true"
-  })
+    # Radio de círculos proporcional a la cantidad de paquetes
+    # Escala: min 15px (1 paquete) → max 50px (18 paquetes)
+    max_n <- max(puntos_mapa$n_paquetes)
+    radios <- scales::rescale(puntos_mapa$n_paquetes, to = c(15, 50))
+    puntos_mapa$radio <- radios
 
-  # Paleta de colores para el mapa (claro → azul oscuro según densidad)
-  paleta_mapa <- colorNumeric(
-    palette = c("#E8F0F5", "#447099", "#151515"),
-    domain = c(0, max_paquetes),
-    na.color = "#F0F0F0"
-  )
-
-  # Renderizar mapa leaflet
-  output$mapa_paquetes <- renderLeaflet({
-    req(shapes_mapa)
-
-    pal <- paleta_mapa
-
-    leaflet(shapes_mapa) |>
-      addTiles() |>
-      addPolygons(
-        layerId = ~name_en,
-        fillColor = ~pal(n_paquetes),
-        fillOpacity = 0.7,
-        color = "#151515",
-        weight = 1.5,
-        dashArray = "",
-        highlight = highlightOptions(
-          weight = 3,
-          color = "#EE6331",
-          dashArray = "",
-          fillOpacity = 0.5,
-          bringToFront = TRUE
-        ),
-        label = sprintf(
-          "%s: %d paquete%s",
-          shapes_mapa$name_en,
-          shapes_mapa$n_paquetes,
-          ifelse(shapes_mapa$n_paquetes != 1, "s", "")
-        ),
-        labelOptions = labelOptions(
-          style = list("font-weight" = "bold", "color" = "#151515"),
-          textsize = "14px",
-          direction = "auto"
+    maplibre(
+      style = carto_style("positron"),
+      projection = "globe",
+      center = c(-60, -15),
+      zoom = 1.2,
+      pitch = 20
+    ) |>
+      add_circle_layer(
+        id = "paquetes_paises",
+        source = puntos_mapa,
+        circle_color = "#447099",
+        circle_radius = "get",
+        circle_opacity = 0.7,
+        circle_stroke_color = "#151515",
+        circle_stroke_width = 1.5,
+        circle_stroke_opacity = 0.8,
+        popup = paste0(
+          "<strong>", puntos_mapa$pais, "</strong><br>",
+          puntos_mapa$n_paquetes,
+          " paquete", ifelse(puntos_mapa$n_paquetes != 1, "s", "")
         )
-      ) |>
-      setView(lng = -60, lat = -15, zoom = 3) |>
-      addLegend(
-        position = "bottomright",
-        pal = pal,
-        values = ~n_paquetes,
-        title = "Paquetes",
-        opacity = 0.7,
-        labFormat = labelFormat(big.mark = ".")
       )
   })
 
-  # Click en un país del mapa → filtrar catálogo
-  observeEvent(input$mapa_paquetes_shape_click, {
-    click <- input$mapa_paquetes_shape_click
+  # Click en un país del globo → filtrar catálogo y cambiar de tab
+  observeEvent(input$mapa_globo_layer_click, {
+    click <- input$mapa_globo_layer_click
     if (is.null(click)) return()
 
-    pais_click <- click$id
-    mapa_pais_sel(pais_click)
+    # click puede traer propiedades del feature; buscar el país
+    pais_click <- NULL
+    if (!is.null(click$properties)) {
+      pais_click <- click$properties$pais
+    } else if (!is.null(click$pais)) {
+      pais_click <- click$pais
+    }
+
+    if (is.null(pais_click) || pais_click == "") return()
 
     # Actualizar el filtro de país del catálogo
     updatePickerInput(session, "pais", selected = pais_click)
@@ -609,29 +608,13 @@ server <- function(input, output, session) {
     updateNavsetCardTab(session, "tab_principal", selected = "tab_catalogo")
   })
 
-  # Info del país seleccionado en el mapa
-  output$mapa_pais_seleccionado <- renderUI({
-    pais <- mapa_pais_sel()
-    if (is.null(pais)) return(NULL)
-    n <- sum(paquetes$pais == pais, na.rm = TRUE)
-    div(
-      strong(icon("filter"), " Filtrando por: ", pais),
-      span(style = "color: #6c757d;", sprintf(" (%d paquete%s)", n, ifelse(n != 1, "s", "")))
-    )
+  # Botón "Ver todos los paquetes" → ir al catálogo sin filtro
+  observeEvent(input$ir_catalogo, {
+    updateNavsetCardTab(session, "tab_principal", selected = "tab_catalogo")
   })
 
-  # Limpiar filtro del mapa
-  observeEvent(input$limpiar_mapa, {
-    mapa_pais_sel(NULL)
-    updatePickerInput(session, "pais", selected = "")
-  })
+  # --- Datos filtrados reactivos ---
 
-  # Cuando se limpia el filtro general, también limpiar info del mapa
-  observeEvent(input$limpiar, {
-    mapa_pais_sel(NULL)
-  })
-
-  # Datos filtrados reactivos
   datos_filtrados <- reactive({
     req(paquetes)
     datos <- paquetes
@@ -660,20 +643,20 @@ server <- function(input, output, session) {
     datos
   })
 
-  # Estadísticas en header
+  # Estadísticas (sobre datos completos, no filtrados, para el landing)
   output$total_paquetes <- renderText({
-    req(datos_filtrados())
-    nrow(datos_filtrados())
+    req(paquetes)
+    nrow(paquetes)
   })
 
   output$total_paises <- renderText({
-    req(datos_filtrados())
-    n_distinct(datos_filtrados()$pais, na.rm = TRUE)
+    req(paquetes)
+    n_distinct(paquetes$pais[paquetes$pais != "No especificado"], na.rm = TRUE)
   })
 
   output$total_categorias <- renderText({
-    req(datos_filtrados())
-    n_distinct(datos_filtrados()$nro_tematica)
+    req(paquetes)
+    n_distinct(paquetes$nro_tematica)
   })
 
   # Info de resultados
@@ -701,7 +684,7 @@ server <- function(input, output, session) {
         div(
           class = "text-center",
           style = "padding: 60px 20px;",
-          icon("search", style = "font-size: 4rem; color: #ccc;"),
+          icon("search", style = "font-size: 4rem; color: #C2C2C4;"),
           h4("No se encontraron paquetes", style = "color: #707073; margin-top: 20px;"),
           p("Intenta ajustar los filtros de búsqueda")
         )
@@ -749,7 +732,6 @@ server <- function(input, output, session) {
                 onerror = "this.style.display='none'; this.nextElementSibling.style.display='inline-block';"
               )
             },
-            # Ícono de fallback (siempre presente pero oculto si la imagen carga)
             icon("cube", style = sprintf(
               "font-size: 2.5rem; color: #447099; margin-right: 15px; display: %s;",
               if (!is.na(pkg$icono) && pkg$icono != "") "none" else "inline-block"
@@ -782,7 +764,6 @@ server <- function(input, output, session) {
       )
     })
 
-    # Devolver todas las tarjetas
     do.call(tagList, tarjetas)
   })
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -149,8 +149,8 @@
       "description": {
         "Package": "Rcpp",
         "Title": "Seamless R and C++ Integration",
-        "Version": "1.1.1-1.1",
-        "Date": "2026-04-19",
+        "Version": "1.1.2",
+        "Date": "2026-07-01",
         "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\",\n                    comment = c(ORCID = \"0000-0001-6419-907X\")),\n             person(\"Romain\", \"Francois\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0002-2444-4226\")),\n             person(\"JJ\", \"Allaire\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0003-0174-9868\")),\n             person(\"Kevin\", \"Ushey\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0003-2880-7407\")),\n             person(\"Qiang\", \"Kou\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-6786-5453\")),\n             person(\"Nathan\", \"Russell\", role = \"aut\"),\n             person(\"Iñaki\", \"Ucar\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-6403-5550\")),\n             person(\"Doug\", \"Bates\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-8316-9503\")),\n             person(\"John\", \"Chambers\", role = \"aut\"))",
         "Description": "The 'Rcpp' package provides R functions as well as C++ classes which\n offer a seamless integration of R and C++. Many R data types and objects can be\n mapped back and forth to C++ equivalents which facilitates both writing of new\n code as well as easier integration of third-party libraries. Documentation\n about 'Rcpp' is provided by several vignettes included in this package, via the\n 'Rcpp Gallery' site at <https://gallery.rcpp.org>, the paper by Eddelbuettel and\n Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013,\n <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018,\n <doi:10.1080/00031305.2017.1375990>); see 'citation(\"Rcpp\")' for details.",
         "Depends": "R (>= 3.5.0)",
@@ -159,17 +159,16 @@
         "URL": "https://www.rcpp.org,\nhttps://dirk.eddelbuettel.com/code/rcpp.html,\nhttps://github.com/RcppCore/Rcpp",
         "License": "GPL (>= 2)",
         "BugReports": "https://github.com/RcppCore/Rcpp/issues",
-        "MailingList": "rcpp-devel@lists.r-forge.r-project.org",
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "VignetteBuilder": "Rcpp",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-23 14:12:31 UTC; edd",
+        "Packaged": "2026-07-01 11:00:56 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  JJ Allaire [aut] (ORCID: <https://orcid.org/0000-0003-0174-9868>),\n  Kevin Ushey [aut] (ORCID: <https://orcid.org/0000-0003-2880-7407>),\n  Qiang Kou [aut] (ORCID: <https://orcid.org/0000-0001-6786-5453>),\n  Nathan Russell [aut],\n  Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>),\n  Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>),\n  John Chambers [aut]",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-24 05:30:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 14:16:04 UTC; unix"
+        "Date/Publication": "2026-07-05 08:30:08 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 12:59:18 UTC; unix"
       }
     },
     "S7": {
@@ -406,7 +405,7 @@
       "description": {
         "Package": "bslib",
         "Title": "Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'",
-        "Version": "0.10.0",
+        "Version": "0.12.0",
         "Authors@R": "c(\n    person(\"Carson\", \"Sievert\", , \"carson@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-4958-2844\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(, \"Bootstrap contributors\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Twitter, Inc\", role = \"cph\",\n           comment = \"Bootstrap library\"),\n    person(\"Javi\", \"Aguilar\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap colorpicker library\"),\n    person(\"Thomas\", \"Park\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootswatch library\"),\n    person(, \"PayPal\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap accessibility plugin\")\n  )",
         "Description": "Simplifies custom 'CSS' styling of both 'shiny' and\n    'rmarkdown' via 'Bootstrap' 'Sass'. Supports 'Bootstrap' 3, 4 and 5 as\n    well as their various 'Bootswatch' themes. An interactive widget is\n    also provided for previewing themes in real time.",
         "License": "MIT + file LICENSE",
@@ -414,23 +413,23 @@
         "BugReports": "https://github.com/rstudio/bslib/issues",
         "Depends": "R (>= 2.10)",
         "Imports": "base64enc, cachem, fastmap (>= 1.1.1), grDevices, htmltools\n(>= 0.5.8), jquerylib (>= 0.1.3), jsonlite, lifecycle, memoise\n(>= 2.0.1), mime, rlang, sass (>= 0.4.9)",
-        "Suggests": "brand.yml, bsicons, curl, fontawesome, future, ggplot2,\nknitr, lattice, magrittr, rappdirs, rmarkdown (>= 2.7), shiny\n(>= 1.11.1), testthat, thematic, tools, utils, withr, yaml",
+        "Suggests": "brand.yml, bsicons, curl, fontawesome, future, ggplot2,\nknitr, lattice, magrittr, rappdirs, rmarkdown (>= 2.7), shiny\n(>= 1.11.1.9000), testthat, thematic, tools, utils, withr, yaml",
         "Config/Needs/deploy": "BH, chiflights22, colourpicker, commonmark, cpp11,\ncpsievert/chiflights22, cpsievert/histoslider, dplyr, DT,\nggplot2, ggridges, gt, hexbin, histoslider, htmlwidgets,\nlattice, leaflet, lubridate, markdown, modelr, plotly,\nreactable, reshape2, rprojroot, rsconnect, rstudio/shiny,\nscales, styler, tibble",
         "Config/Needs/routine": "chromote, desc, renv",
         "Config/Needs/website": "brio, crosstalk, dplyr, DT, ggplot2, glue,\nhtmlwidgets, leaflet, lorem, palmerpenguins, plotly, purrr,\nrprojroot, rstudio/htmltools, scales, stringr, tidyr, webshot2",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Config/testthat/parallel": "true",
         "Config/testthat/start-first": "zzzz-bs-sass, fonts, zzz-precompile,\ntheme-*, rmd-*",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R'\n'bs-dependencies.R' 'bs-global.R' 'bs-remove.R'\n'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R'\n'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R'\n'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R'\n'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R'\n'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R'\n'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R'\n'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R'\n'navbar_options.R' 'navs-legacy.R' 'navs.R' 'onLoad.R' 'page.R'\n'popover.R' 'precompiled.R' 'print.R' 'shiny-devmode.R'\n'sidebar.R' 'staticimports.R' 'toast.R' 'tooltip.R'\n'utils-deps.R' 'utils-shiny.R' 'utils-tags.R' 'value-box.R'\n'version-default.R' 'versions.R'",
+        "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R'\n'bs-dependencies.R' 'bs-global.R' 'bs-remove.R'\n'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R'\n'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R'\n'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R'\n'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R'\n'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R'\n'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R'\n'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R'\n'navbar_options.R' 'navs-legacy.R' 'navs.R' 'offcanvas.R'\n'onLoad.R' 'page.R' 'popover.R' 'precompiled.R' 'print.R'\n'shiny-devmode.R' 'sidebar.R' 'staticimports.R' 'toast.R'\n'toolbar.R' 'tooltip.R' 'utils-deps.R' 'utils-shiny.R'\n'utils-tags.R' 'value-box.R' 'version-default.R' 'versions.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2026-01-22 00:32:06 UTC; garrick",
+        "Packaged": "2026-08-03 22:55:38 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Posit Software, PBC [cph, fnd],\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Javi Aguilar [ctb, cph] (Bootstrap colorpicker library),\n  Thomas Park [ctb, cph] (Bootswatch library),\n  PayPal [ctb, cph] (Bootstrap accessibility plugin)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-01-26 08:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-30 15:59:49 UTC; unix"
+        "Date/Publication": "2026-08-04 00:40:02 UTC",
+        "Built": "R 4.6.1; ; 2026-08-21 12:59:51 UTC; unix"
       }
     },
     "cachem": {
@@ -1193,6 +1192,66 @@
         "Built": "R 4.6.0; ; 2026-04-24 01:24:54 UTC; unix"
       }
     },
+    "geojsonsf": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "geojsonsf",
+        "Type": "Package",
+        "Title": "GeoJSON to Simple Feature Converter",
+        "Version": "2.0.5",
+        "Date": "2025-11-25",
+        "Authors@R": "c(\n    person(\"David\", \"Cooley\", ,\"dcooley@symbolix.com.au\", role = c(\"aut\", \"cre\")),\n    person(\"Andy\", \"Teucher\", ,\"andy.teucher@gmail.com\", role = \"ctb\")\n    )",
+        "Description": "Converts Between GeoJSON and simple feature objects. ",
+        "License": "MIT + file LICENSE",
+        "URL": "https://github.com/SymbolixAU/geojsonsf",
+        "BugReports": "https://github.com/SymbolixAU/geojsonsf/issues",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "Depends": "R (>= 4.0.0)",
+        "Imports": "Rcpp (>= 1.1.0)",
+        "LinkingTo": "geometries (>= 0.2.5), jsonify (>= 1.2.3), rapidjsonr (>=\n1.2.1), Rcpp, sfheaders (>= 0.4.5)",
+        "RoxygenNote": "7.3.3",
+        "Suggests": "covr, jsonify, knitr, rmarkdown, tinytest",
+        "VignetteBuilder": "knitr",
+        "NeedsCompilation": "yes",
+        "Packaged": "2025-11-26 08:50:31 UTC; david",
+        "Author": "David Cooley [aut, cre],\n  Andy Teucher [ctb]",
+        "Maintainer": "David Cooley <dcooley@symbolix.com.au>",
+        "Repository": "CRAN",
+        "Date/Publication": "2025-11-26 10:00:02 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 13:09:04 UTC; unix"
+      }
+    },
+    "geometries": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "geometries",
+        "Type": "Package",
+        "Title": "Convert Between R Objects and Geometric Structures",
+        "Date": "2025-11-23",
+        "Version": "0.2.5",
+        "Authors@R": "c(\n    person(\"David\", \"Cooley\", ,\"david.cooley.au@gmail.com\", role = c(\"aut\", \"cre\"))\n    )",
+        "Description": "Geometry shapes in 'R' are typically represented by matrices (points, lines), with more complex \n  shapes being lists of matrices (polygons). 'Geometries' will convert various 'R' objects into these shapes. \n  Conversion functions are available at both the 'R' level, and through 'Rcpp'.",
+        "License": "MIT + file LICENSE",
+        "URL": "https://dcooley.github.io/geometries/",
+        "BugReports": "https://github.com/dcooley/geometries/issues",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "7.2.3",
+        "LinkingTo": "Rcpp",
+        "Imports": "Rcpp (>= 1.1.0)",
+        "Suggests": "covr, knitr, rmarkdown, tinytest",
+        "VignetteBuilder": "knitr",
+        "NeedsCompilation": "yes",
+        "Packaged": "2025-11-23 16:09:52 UTC; david",
+        "Author": "David Cooley [aut, cre]",
+        "Maintainer": "David Cooley <david.cooley.au@gmail.com>",
+        "Repository": "CRAN",
+        "Date/Publication": "2025-11-23 16:30:02 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 13:03:10 UTC; unix"
+      }
+    },
     "ggplot2": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -1634,6 +1693,35 @@
         "Built": "R 4.6.0; ; 2026-04-30 14:18:06 UTC; unix"
       }
     },
+    "jsonify": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "jsonify",
+        "Type": "Package",
+        "Title": "Convert Between 'R' Objects and Javascript Object Notation\n(JSON)",
+        "Version": "1.2.3",
+        "Date": "2025-11-24",
+        "Authors@R": "c(\n    person(\"David\", \"Cooley\", ,\"dcooley@symbolix.com.au\", role = c(\"aut\", \"cre\")),\n    person(\"Chris\", \"Muir\", role = \"ctb\"),\n    person(\"Brendan\", \"Knapp\", role = \"ctb\", comment = c(ORCID = \"0000-0003-3284-4972\"))\n    )",
+        "Description": "Conversions between 'R' objects and Javascript Object Notation (JSON) using \n    the 'rapidjsonr' library <https://CRAN.R-project.org/package=rapidjsonr>. ",
+        "License": "MIT + file LICENSE",
+        "Depends": "R (>= 4.0.0)",
+        "Imports": "Rcpp (>= 1.1.0)",
+        "LinkingTo": "rapidjsonr (>= 1.2.1), Rcpp",
+        "RoxygenNote": "7.3.2",
+        "Suggests": "covr, testthat, knitr, rmarkdown",
+        "Encoding": "UTF-8",
+        "URL": "https://symbolixau.github.io/jsonify/,\nhttps://github.com/SymbolixAU/jsonify",
+        "BugReports": "https://github.com/SymbolixAU/jsonify/issues",
+        "NeedsCompilation": "yes",
+        "Packaged": "2025-11-24 13:03:46 UTC; david",
+        "Author": "David Cooley [aut, cre],\n  Chris Muir [ctb],\n  Brendan Knapp [ctb] (ORCID: <https://orcid.org/0000-0003-3284-4972>)",
+        "Maintainer": "David Cooley <dcooley@symbolix.com.au>",
+        "Repository": "CRAN",
+        "Date/Publication": "2025-11-25 19:22:12 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 13:01:58 UTC; unix"
+      }
+    },
     "jsonlite": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -1746,35 +1834,6 @@
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 14:17:41 UTC; unix"
       }
     },
-    "lattice": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "description": {
-        "Package": "lattice",
-        "Version": "0.23-1",
-        "Date": "2026-08-08",
-        "Priority": "recommended",
-        "Title": "Trellis Graphics for R",
-        "Authors@R": "c(person(\"Deepayan\", \"Sarkar\", role = c(\"aut\", \"cre\"),\n\t            email = \"deepayan.sarkar@r-project.org\",\n\t\t    comment = c(ORCID = \"0000-0003-4107-1553\")),\n              person(\"Felix\", \"Andrews\", role = \"ctb\"),\n\t      person(\"Kevin\", \"Wright\", role = \"ctb\", comment = \"documentation\"),\n\t      person(\"Neil\", \"Klepeis\", role = \"ctb\"),\n\t      person(\"Johan\", \"Larsson\", role = \"ctb\", comment = \"miscellaneous improvements\"),\n              person(\"Zhijian (Jason)\", \"Wen\", role = \"cph\", comment = \"filled contour code\"),\n              person(\"Paul\", \"Murrell\", role = \"ctb\", email = \"paul@stat.auckland.ac.nz\"),\n\t      person(\"Stefan\", \"Eng\", role = \"ctb\", comment = \"violin plot improvements\"),\n\t      person(\"Achim\", \"Zeileis\", role = \"ctb\", comment = \"modern colors\"),\n              person(\"Alexandre\", \"Courtiol\", role = \"ctb\",\n                     comment = \"generics for larrows, lpolygon, lrect and lsegments\")\n\t      )",
-        "Description": "A powerful and elegant high-level data visualization\n  system inspired by Trellis graphics, with an emphasis on\n  multivariate data. Lattice is sufficient for typical graphics needs,\n  and is also flexible enough to handle most nonstandard requirements.\n  See ?Lattice for an introduction.",
-        "Depends": "R (>= 4.0.0)",
-        "Suggests": "KernSmooth, MASS, latticeExtra, colorspace",
-        "Imports": "grid, grDevices, graphics, stats, utils",
-        "Enhances": "chron, zoo",
-        "LazyLoad": "yes",
-        "LazyData": "yes",
-        "License": "GPL (>= 2)",
-        "URL": "https://lattice.r-forge.r-project.org/",
-        "BugReports": "https://github.com/deepayan/lattice/issues",
-        "NeedsCompilation": "yes",
-        "Packaged": "2026-08-12 08:02:41 UTC; deepayan",
-        "Author": "Deepayan Sarkar [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4107-1553>),\n  Felix Andrews [ctb],\n  Kevin Wright [ctb] (documentation),\n  Neil Klepeis [ctb],\n  Johan Larsson [ctb] (miscellaneous improvements),\n  Zhijian (Jason) Wen [cph] (filled contour code),\n  Paul Murrell [ctb],\n  Stefan Eng [ctb] (violin plot improvements),\n  Achim Zeileis [ctb] (modern colors),\n  Alexandre Courtiol [ctb] (generics for larrows, lpolygon, lrect and\n    lsegments)",
-        "Maintainer": "Deepayan Sarkar <deepayan.sarkar@r-project.org>",
-        "Repository": "CRAN",
-        "Date/Publication": "2026-08-12 14:43:29 UTC",
-        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 'Mon, 17 Aug 2026 01:55:56 +0000'; unix"
-      }
-    },
     "lazyeval": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -1799,67 +1858,6 @@
         "Date/Publication": "2026-04-04 05:10:53 UTC",
         "Encoding": "UTF-8",
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 02:20:56 UTC; unix"
-      }
-    },
-    "leaflet": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "description": {
-        "Type": "Package",
-        "Package": "leaflet",
-        "Title": "Create Interactive Web Maps with the JavaScript 'Leaflet'\nLibrary",
-        "Version": "2.2.3",
-        "Authors@R": "c(\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"),\n    person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-9986-114X\")),\n    person(\"Bhaskar\", \"Karambelkar\", role = \"aut\"),\n    person(\"Yihui\", \"Xie\", role = \"aut\"),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Hadley\", \"Wickham\", role = \"ctb\"),\n    person(\"Kenton\", \"Russell\", role = \"ctb\"),\n    person(\"Kent\", \"Johnson\", role = \"ctb\"),\n    person(\"Vladimir\", \"Agafonkin\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet library\"),\n    person(\"CloudMade\", role = \"cph\",\n           comment = \"Leaflet library\"),\n    person(\"Leaflet contributors\", role = \"ctb\",\n           comment = \"Leaflet library\"),\n    person(\"Brandon Copeland\", role = c(\"ctb\", \"cph\"),\n           comment = \"leaflet-measure plugin\"),\n    person(\"Joerg Dietrich\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet.Terminator plugin\"),\n    person(\"Benjamin Becquet\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet.MagnifyingGlass plugin\"),\n    person(\"Norkart AS\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet.MiniMap plugin\"),\n    person(\"L. Voogdt\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet.awesome-markers plugin\"),\n    person(\"Daniel Montague\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet.EasyButton plugin\"),\n    person(\"Kartena AB\", role = c(\"ctb\", \"cph\"),\n           comment = \"Proj4Leaflet plugin\"),\n    person(\"Robert Kajic\", role = c(\"ctb\", \"cph\"),\n           comment = \"leaflet-locationfilter plugin\"),\n    person(\"Mapbox\", role = c(\"ctb\", \"cph\"),\n           comment = \"leaflet-omnivore plugin\"),\n    person(\"Michael Bostock\", role = c(\"ctb\", \"cph\"),\n           comment = \"topojson\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"))\n  )",
-        "Description": "Create and customize interactive maps using the 'Leaflet'\n    JavaScript library and the 'htmlwidgets' package. These maps can be\n    used directly from the R console, from 'RStudio', in Shiny\n    applications and R Markdown documents.",
-        "License": "MIT + file LICENSE",
-        "URL": "https://rstudio.github.io/leaflet/,\nhttps://github.com/rstudio/leaflet",
-        "BugReports": "https://github.com/rstudio/leaflet/issues",
-        "Depends": "R (>= 3.5)",
-        "Imports": "crosstalk, htmltools, htmlwidgets (>= 1.5.4), jquerylib,\nleaflet.providers (>= 2.0.0), magrittr, methods, png, raster\n(>= 3.6.3), RColorBrewer, rlang, scales (>= 1.0.0), sf (>=\n0.9-6), stats, viridisLite, xfun",
-        "Suggests": "knitr, maps, purrr, R6, RJSONIO, rmarkdown, s2, shiny (>=\n1.0.0), sp, terra, testthat (>= 3.0.0)",
-        "Config/Needs/website": "dplyr, ncdf4, rnaturalearth,\ntidyverse/tidytemplate",
-        "Config/testthat/edition": "3",
-        "Encoding": "UTF-8",
-        "LazyData": "true",
-        "RoxygenNote": "7.3.2",
-        "NeedsCompilation": "no",
-        "Packaged": "2025-09-02 15:28:47 UTC; garrick",
-        "Author": "Joe Cheng [aut],\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Bhaskar Karambelkar [aut],\n  Yihui Xie [aut],\n  Garrick Aden-Buie [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Hadley Wickham [ctb],\n  Kenton Russell [ctb],\n  Kent Johnson [ctb],\n  Vladimir Agafonkin [ctb, cph] (Leaflet library),\n  CloudMade [cph] (Leaflet library),\n  Leaflet contributors [ctb] (Leaflet library),\n  Brandon Copeland [ctb, cph] (leaflet-measure plugin),\n  Joerg Dietrich [ctb, cph] (Leaflet.Terminator plugin),\n  Benjamin Becquet [ctb, cph] (Leaflet.MagnifyingGlass plugin),\n  Norkart AS [ctb, cph] (Leaflet.MiniMap plugin),\n  L. Voogdt [ctb, cph] (Leaflet.awesome-markers plugin),\n  Daniel Montague [ctb, cph] (Leaflet.EasyButton plugin),\n  Kartena AB [ctb, cph] (Proj4Leaflet plugin),\n  Robert Kajic [ctb, cph] (leaflet-locationfilter plugin),\n  Mapbox [ctb, cph] (leaflet-omnivore plugin),\n  Michael Bostock [ctb, cph] (topojson),\n  Posit Software, PBC [cph, fnd]",
-        "Maintainer": "Garrick Aden-Buie <garrick@posit.co>",
-        "Repository": "RSPM",
-        "Date/Publication": "2025-09-04 07:40:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 22:50:51 UTC; unix"
-      }
-    },
-    "leaflet.providers": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "description": {
-        "Type": "Package",
-        "Package": "leaflet.providers",
-        "Title": "Leaflet Providers",
-        "Version": "3.0.0",
-        "Authors@R": "c(\n    person(\"Leslie\", \"Huang\", , \"lesliehuang@nyu.edu\", role = \"aut\"),\n    person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = c(\"ctb\", \"cre\"),\n           comment = c(ORCID = \"0000-0001-9986-114X\")),\n    person(\"Leaflet Providers contributors\", role = c(\"ctb\", \"cph\"),\n           comment = \"Leaflet Providers plugin\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"https://ror.org/03wc8by49\"))\n  )",
-        "Description": "Contains third-party map tile provider information from\n    'Leaflet.js', <https://github.com/leaflet-extras/leaflet-providers>,\n    to be used with the 'leaflet' R package. Additionally,\n    'leaflet.providers' enables users to retrieve up-to-date provider\n    information between package updates.",
-        "License": "BSD_2_clause + file LICENSE",
-        "URL": "https://rstudio.github.io/leaflet.providers/,\nhttps://github.com/rstudio/leaflet.providers",
-        "BugReports": "https://github.com/rstudio/leaflet.providers/issues",
-        "Depends": "R (>= 2.10)",
-        "Imports": "htmltools",
-        "Suggests": "jsonlite, testthat (>= 3.0.0), V8",
-        "Config/Needs/website": "tidyverse/tidytemplate",
-        "Config/testthat/edition": "3",
-        "Encoding": "UTF-8",
-        "Language": "en-US",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'providers_data.R' 'get_current_providers.R'\n'leaflet.providers-package.R' 'zzz.R'",
-        "NeedsCompilation": "no",
-        "Packaged": "2026-03-18 17:18:39 UTC; barret",
-        "Author": "Leslie Huang [aut],\n  Barret Schloerke [ctb, cre] (ORCID:\n    <https://orcid.org/0000-0001-9986-114X>),\n  Leaflet Providers contributors [ctb, cph] (Leaflet Providers plugin),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
-        "Maintainer": "Barret Schloerke <barret@posit.co>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-03-18 21:50:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 02:45:29 UTC; unix"
       }
     },
     "lifecycle": {
@@ -1952,6 +1950,44 @@
         "Repository": "CRAN",
         "Date/Publication": "2026-04-04 08:00:02 UTC",
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 14:16:29 UTC; unix"
+      }
+    },
+    "mapgl": {
+      "Source": "github",
+      "Repository": null,
+      "description": {
+        "Package": "mapgl",
+        "Title": "Interactive Maps with 'Mapbox GL JS' and 'MapLibre GL JS'",
+        "Version": "0.5.1.9000",
+        "Date": "2026-08-20",
+        "Authors@R": "c(\n    person(given = \"Kyle\", family = \"Walker\", email = \"kyle@walker-data.com\", role = c(\"aut\", \"cre\")),\n    person(given = \"Egor\", family = \"Kotov\", email = \"kotov.egor@gmail.com\", role = \"ctb\"))",
+        "Description": "Provides an interface to the 'Mapbox GL JS' (<https://docs.mapbox.com/mapbox-gl-js/guides>)\n    and the 'MapLibre GL JS' (<https://maplibre.org/maplibre-gl-js/docs/>) interactive mapping libraries to help users\n    create custom interactive maps in R.  Users can create interactive globe visualizations; layer 'sf' objects to create\n    filled maps, circle maps, 'heatmaps', and three-dimensional graphics; and customize map styles and views.  The package\n    also includes utilities to use 'Mapbox' and 'MapLibre' maps in 'Shiny' web applications.",
+        "URL": "https://walker-data.com/mapgl/",
+        "BugReports": "https://github.com/walkerke/mapgl/issues",
+        "License": "MIT + file LICENSE",
+        "Encoding": "UTF-8",
+        "LazyData": "true",
+        "Roxygen": "list(markdown = TRUE)",
+        "Depends": "R (>= 4.1.0)",
+        "Imports": "htmlwidgets, geojsonsf, sf, rlang, htmltools, grDevices,\nbase64enc, terra, classInt, shiny, viridisLite, png, jsonlite,\nhttpuv",
+        "Suggests": "chromote, knitr, mapboxapi, testthat (>= 3.0.0), usethis,\nleaflet, withr",
+        "Config/testthat/edition": "3",
+        "Config/roxygen2/version": "8.0.0",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "mapgl",
+        "RemoteUsername": "walkerke",
+        "RemoteRef": "HEAD",
+        "RemoteSha": "09e56c429bdb643478413c4a7987f60bc7315a45",
+        "GithubRepo": "mapgl",
+        "GithubUsername": "walkerke",
+        "GithubRef": "HEAD",
+        "GithubSHA1": "09e56c429bdb643478413c4a7987f60bc7315a45",
+        "NeedsCompilation": "no",
+        "Packaged": "2026-08-21 13:15:54 UTC; pablote",
+        "Author": "Kyle Walker [aut, cre],\n  Egor Kotov [ctb]",
+        "Maintainer": "Kyle Walker <kyle@walker-data.com>",
+        "Built": "R 4.6.1; ; 2026-08-21 13:15:58 UTC; unix"
       }
     },
     "memoise": {
@@ -2404,6 +2440,30 @@
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 21:55:10 UTC; unix"
       }
     },
+    "rapidjsonr": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "rapidjsonr",
+        "Type": "Package",
+        "Title": "'Rapidjson' C++ Header Files",
+        "Version": "1.2.1",
+        "Date": "2025-11-23",
+        "Authors@R": "c(\n    person(\"David\", \"Cooley\", ,\"dcooley@symbolix.com.au\", role = c(\"aut\", \"cre\")),\n    person(\"Milo\", \"Yip\", , role = \"ctb\", comment = \"Author of c++ rapidjson library, provided through THL A29 Limited, a Tencent company\"),\n    person(\"Alexander\", \"Chemeris\", role = \"ctb\", comment = \"Author of c++ msinttypes library\")\n    )",
+        "Description": "Provides JSON parsing capability through the 'Rapidjson' 'C++' header-only library. ",
+        "License": "MIT + file LICENSE",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "7.3.1",
+        "SystemRequirements": "GNU make",
+        "NeedsCompilation": "no",
+        "Packaged": "2025-11-23 16:12:43 UTC; david",
+        "Author": "David Cooley [aut, cre],\n  Milo Yip [ctb] (Author of c++ rapidjson library, provided through THL\n    A29 Limited, a Tencent company),\n  Alexander Chemeris [ctb] (Author of c++ msinttypes library)",
+        "Maintainer": "David Cooley <dcooley@symbolix.com.au>",
+        "Repository": "CRAN",
+        "Date/Publication": "2025-11-24 08:50:07 UTC",
+        "Built": "R 4.6.1; ; 2026-08-21 13:01:42 UTC; unix"
+      }
+    },
     "rappdirs": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -2432,34 +2492,6 @@
         "Repository": "CRAN",
         "Date/Publication": "2026-01-17 08:40:02 UTC",
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 14:15:51 UTC; unix"
-      }
-    },
-    "raster": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "description": {
-        "Package": "raster",
-        "Type": "Package",
-        "Title": "Geographic Data Analysis and Modeling",
-        "Version": "3.6-32",
-        "Date": "2025-03-27",
-        "Imports": "Rcpp, methods, terra (>= 1.8-5)",
-        "LinkingTo": "Rcpp",
-        "Depends": "sp (>= 1.4-5), R (>= 3.5.0)",
-        "Suggests": "ncdf4, igraph, tcltk, parallel, rasterVis, MASS, sf,\ntinytest, gstat, fields, exactextractr",
-        "Description": "Reading, writing, manipulating, analyzing and modeling of spatial data. This package has been superseded by the \"terra\" package <https://CRAN.R-project.org/package=terra>. ",
-        "License": "GPL (>= 3)",
-        "URL": "https://rspatial.org/raster",
-        "BugReports": "https://github.com/rspatial/raster/issues/",
-        "Authors@R": "c(\n\tperson(\"Robert J.\", \"Hijmans\", role = c(\"cre\", \"aut\"),  \n\t\t\temail = \"r.hijmans@gmail.com\", \n\t\t\tcomment = c(ORCID = \"0000-0001-5872-2872\")),\n\tperson(\"Jacob\", \"van Etten\", role = \"ctb\"),\n\tperson(\"Michael\", \"Sumner\", role = \"ctb\"),\n\tperson(\"Joe\", \"Cheng\", role = \"ctb\"),\n\tperson(\"Dan\", \"Baston\", role = \"ctb\"),\n\tperson(\"Andrew\", \"Bevan\", role = \"ctb\"),\n\tperson(\"Roger\", \"Bivand\", role = \"ctb\"),\n\tperson(\"Lorenzo\", \"Busetto\", role = \"ctb\"),\n\tperson(\"Mort\", \"Canty\", role = \"ctb\"),\n\tperson(\"Ben\", \"Fasoli\", role = \"ctb\"),\n\tperson(\"David\", \"Forrest\", role = \"ctb\"),\n\tperson(\"Aniruddha\", \"Ghosh\", role = \"ctb\"),\n\tperson(\"Duncan\", \"Golicher\", role = \"ctb\"),\n\tperson(\"Josh\", \"Gray\", role = \"ctb\"),\n\tperson(\"Jonathan A.\", \"Greenberg\", role = \"ctb\"),\n\tperson(\"Paul\", \"Hiemstra\", role = \"ctb\"),\n\tperson(\"Kassel\", \"Hingee\", role = \"ctb\"),\n\tperson(\"Alex\", \"Ilich\", role = \"ctb\"),\n\tperson(\"Institute for Mathematics Applied Geosciences\", role=\"cph\"),\n\tperson(\"Charles\", \"Karney\", role = \"ctb\"),\n\tperson(\"Matteo\", \"Mattiuzzi\", role = \"ctb\"),\n\tperson(\"Steven\", \"Mosher\", role = \"ctb\"),\n\tperson(\"Babak\", \"Naimi\", role = \"ctb\"),\t\n\tperson(\"Jakub\", \"Nowosad\", role = \"ctb\"),\n\tperson(\"Edzer\", \"Pebesma\", role = \"ctb\"),\n\tperson(\"Oscar\", \"Perpinan Lamigueiro\", role = \"ctb\"),\n\tperson(\"Etienne B.\", \"Racine\", role = \"ctb\"),\n\tperson(\"Barry\", \"Rowlingson\", role = \"ctb\"),\n\tperson(\"Ashton\", \"Shortridge\", role = \"ctb\"),\n\tperson(\"Bill\", \"Venables\", role = \"ctb\"),\n\tperson(\"Rafael\", \"Wueest\", role = \"ctb\")\n\t)",
-        "NeedsCompilation": "yes",
-        "Packaged": "2025-03-28 04:28:45 UTC; rhijm",
-        "Author": "Robert J. Hijmans [cre, aut] (<https://orcid.org/0000-0001-5872-2872>),\n  Jacob van Etten [ctb],\n  Michael Sumner [ctb],\n  Joe Cheng [ctb],\n  Dan Baston [ctb],\n  Andrew Bevan [ctb],\n  Roger Bivand [ctb],\n  Lorenzo Busetto [ctb],\n  Mort Canty [ctb],\n  Ben Fasoli [ctb],\n  David Forrest [ctb],\n  Aniruddha Ghosh [ctb],\n  Duncan Golicher [ctb],\n  Josh Gray [ctb],\n  Jonathan A. Greenberg [ctb],\n  Paul Hiemstra [ctb],\n  Kassel Hingee [ctb],\n  Alex Ilich [ctb],\n  Institute for Mathematics Applied Geosciences [cph],\n  Charles Karney [ctb],\n  Matteo Mattiuzzi [ctb],\n  Steven Mosher [ctb],\n  Babak Naimi [ctb],\n  Jakub Nowosad [ctb],\n  Edzer Pebesma [ctb],\n  Oscar Perpinan Lamigueiro [ctb],\n  Etienne B. Racine [ctb],\n  Barry Rowlingson [ctb],\n  Ashton Shortridge [ctb],\n  Bill Venables [ctb],\n  Rafael Wueest [ctb]",
-        "Maintainer": "Robert J. Hijmans <r.hijmans@gmail.com>",
-        "Repository": "RSPM",
-        "Date/Publication": "2025-03-28 08:10:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 15:25:12 UTC; unix"
       }
     },
     "readr": {
@@ -2792,28 +2824,28 @@
       "description": {
         "Package": "s2",
         "Title": "Spherical Geometry Operators Using the S2 Geometry Library",
-        "Version": "1.1.9",
+        "Version": "1.1.11",
         "Authors@R": "c(\n     person(given = \"Dewey\",\n           family = \"Dunnington\",\n           role = c(\"aut\"),\n           email = \"dewey@fishandwhistle.net\",\n           comment = c(ORCID = \"0000-0002-9415-4582\")),\n     person(given = \"Edzer\",\n             family = \"Pebesma\",\n             role = c(\"aut\", \"cre\"),\n             email = \"edzer.pebesma@uni-muenster.de\",\n             comment = c(ORCID = \"0000-0001-8049-7069\")),\n    person(\"Ege\", \"Rubak\", email=\"rubak@math.aau.dk\", role = c(\"aut\")),\n    person(\"Jeroen\", \"Ooms\", , \"jeroen.ooms@stat.ucla.edu\", role = \"ctb\", comment = \"configure script\"),\n    person(family = \"Google, Inc.\", role = \"cph\", comment = \"Original s2geometry.io source code\")\n  )",
         "Description": "Provides R bindings for Google's s2 library for geometric calculations on\n    the sphere. High-performance constructors and exporters provide high compatibility\n    with existing spatial packages, transformers construct new geometries from existing\n    geometries, predicates provide a means to select geometries based on spatial\n    relationships, and accessors extract information about geometries.",
         "License": "Apache License (== 2.0)",
         "Encoding": "UTF-8",
         "LazyData": "true",
-        "RoxygenNote": "7.3.2",
         "SystemRequirements": "cmake, OpenSSL >= 1.0.1, Abseil >= 20230802.0",
         "LinkingTo": "Rcpp, wk",
         "Imports": "Rcpp, wk (>= 0.6.0)",
         "Suggests": "bit64, testthat (>= 3.0.0), vctrs",
-        "URL": "https://r-spatial.github.io/s2/, https://github.com/r-spatial/s2,\nhttp://s2geometry.io/",
+        "URL": "https://r-spatial.github.io/s2/, https://github.com/r-spatial/s2,\nhttps://s2geometry.io/",
         "BugReports": "https://github.com/r-spatial/s2/issues",
         "Depends": "R (>= 3.0.0)",
         "Config/testthat/edition": "3",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2025-05-23 14:44:45 UTC; edzer",
+        "Packaged": "2026-06-01 09:16:23 UTC; edzer",
         "Author": "Dewey Dunnington [aut] (ORCID: <https://orcid.org/0000-0002-9415-4582>),\n  Edzer Pebesma [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-8049-7069>),\n  Ege Rubak [aut],\n  Jeroen Ooms [ctb] (configure script),\n  Google, Inc. [cph] (Original s2geometry.io source code)",
         "Maintainer": "Edzer Pebesma <edzer.pebesma@uni-muenster.de>",
-        "Repository": "RSPM",
-        "Date/Publication": "2025-05-23 15:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 15:00:10 UTC; unix"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-01 10:30:02 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 13:03:37 UTC; unix"
       }
     },
     "sass": {
@@ -2932,6 +2964,35 @@
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-25 15:18:37 UTC; unix"
       }
     },
+    "sfheaders": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "sfheaders",
+        "Type": "Package",
+        "Title": "Converts Between R Objects and Simple Feature Objects",
+        "Date": "2025-11-24",
+        "Version": "0.4.5",
+        "Authors@R": "c(\n    person(\"David\", \"Cooley\", ,\"david.cooley.au@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(given = \"Michael\", family = \"Sumner\", role = \"ctb\")\n    )",
+        "Description": "Converts between R and Simple Feature 'sf' objects, without depending\n  on the Simple Feature library. Conversion functions are available at both the R level, \n  and through 'Rcpp'.",
+        "License": "MIT + file LICENSE",
+        "URL": "https://dcooley.github.io/sfheaders/",
+        "BugReports": "https://github.com/dcooley/sfheaders/issues",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "7.3.2",
+        "Depends": "R (>= 3.0.2)",
+        "LinkingTo": "geometries (>= 0.2.5), Rcpp",
+        "Imports": "Rcpp (>= 1.1.0)",
+        "Suggests": "covr, knitr, testthat",
+        "NeedsCompilation": "yes",
+        "Packaged": "2025-11-24 13:15:04 UTC; david",
+        "Author": "David Cooley [aut, cre],\n  Michael Sumner [ctb]",
+        "Maintainer": "David Cooley <david.cooley.au@gmail.com>",
+        "Repository": "CRAN",
+        "Date/Publication": "2025-11-25 19:20:02 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 13:16:06 UTC; unix"
+      }
+    },
     "shiny": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -2939,7 +3000,7 @@
         "Type": "Package",
         "Package": "shiny",
         "Title": "Web Application Framework for R",
-        "Version": "1.13.0",
+        "Version": "1.14.0",
         "Authors@R": "c(\n    person(\"Winston\", \"Chang\", , \"winston@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-1576-2126\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"),\n    person(\"JJ\", \"Allaire\", , \"jj@posit.co\", role = \"aut\"),\n    person(\"Carson\", \"Sievert\", , \"carson@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-4958-2844\")),\n    person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-9986-114X\")),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@adenbuie.com\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Yihui\", \"Xie\", , \"yihui@posit.co\", role = \"aut\"),\n    person(\"Jeff\", \"Allen\", role = \"aut\"),\n    person(\"Jonathan\", \"McPherson\", , \"jonathan@posit.co\", role = \"aut\"),\n    person(\"Alan\", \"Dipert\", role = \"aut\"),\n    person(\"Barbara\", \"Borges\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(, \"jQuery Foundation\", role = \"cph\",\n           comment = \"jQuery library and jQuery UI library\"),\n    person(, \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n           comment = \"jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt\"),\n    person(, \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n           comment = \"jQuery UI library; authors listed in inst/www/shared/jqueryui/AUTHORS.txt\"),\n    person(\"Mark\", \"Otto\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(\"Jacob\", \"Thornton\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Bootstrap contributors\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Twitter, Inc\", role = \"cph\",\n           comment = \"Bootstrap library\"),\n    person(\"Prem Nawaz\", \"Khan\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Victor\", \"Tsaran\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Dennis\", \"Lembree\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Srinivasu\", \"Chakravarthula\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Cathy\", \"O'Connor\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(, \"PayPal, Inc\", role = \"cph\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Stefan\", \"Petre\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap-datepicker library\"),\n    person(\"Andrew\", \"Rowls\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap-datepicker library\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"),\n           comment = \"selectize.js library\"),\n    person(\"Salmen\", \"Bejaoui\", role = c(\"ctb\", \"cph\"),\n           comment = \"selectize-plugin-a11y library\"),\n    person(\"Denis\", \"Ineshin\", role = c(\"ctb\", \"cph\"),\n           comment = \"ion.rangeSlider library\"),\n    person(\"Sami\", \"Samhuri\", role = c(\"ctb\", \"cph\"),\n           comment = \"Javascript strftime library\"),\n    person(, \"SpryMedia Limited\", role = c(\"ctb\", \"cph\"),\n           comment = \"DataTables library\"),\n    person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n           comment = \"highlight.js library\"),\n    person(\"R Core Team\", role = c(\"ctb\", \"cph\"),\n           comment = \"tar implementation from R\")\n  )",
         "Description": "Makes it incredibly easy to build interactive web\n    applications with R. Automatic \"reactive\" binding between inputs and\n    outputs and extensive prebuilt widgets make it possible to build\n    beautiful, responsive, and powerful applications with minimal effort.",
         "License": "MIT + file LICENSE",
@@ -2947,19 +3008,19 @@
         "BugReports": "https://github.com/rstudio/shiny/issues",
         "Depends": "methods, R (>= 3.1.2)",
         "Imports": "bslib (>= 0.6.0), cachem (>= 1.1.0), cli, commonmark (>=\n2.0.0), fastmap (>= 1.1.1), fontawesome (>= 0.4.0), glue (>=\n1.3.2), grDevices, htmltools (>= 0.5.4), httpuv (>= 1.5.2),\njsonlite (>= 0.9.16), later (>= 1.0.0), lifecycle (>= 0.2.0),\nmime (>= 0.3), otel, promises (>= 1.5.0), R6 (>= 2.0), rlang\n(>= 0.4.10), sourcetools, tools, utils, withr, xtable",
-        "Suggests": "Cairo (>= 1.5-5), coro (>= 1.1.0), datasets, DT, dygraphs,\nfuture, ggplot2, knitr (>= 1.6), magrittr, markdown, mirai,\notelsdk (>= 0.2.0), ragg, reactlog (>= 1.0.0), rmarkdown, sass,\nshowtext, testthat (>= 3.2.1), watcher, yaml",
-        "Config/Needs/check": "shinytest2",
+        "Suggests": "Cairo (>= 1.5-5), coro (>= 1.1.0), datasets, DT, dygraphs,\nfuture, ggplot2, knitr (>= 1.6), magrittr, markdown, mirai,\notelsdk (>= 0.2.0), ragg, reactlog (>= 1.0.0), rmarkdown, sass,\nshinytest2, showtext, testthat (>= 3.2.1), watcher, yaml",
+        "Config/Needs/check": "shinyjs",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'globals.R' 'app-state.R' 'app_template.R' 'bind-cache.R'\n'bind-event.R' 'bookmark-state-local.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'conditions.R'\n'map.R' 'utils.R' 'bootstrap.R' 'busy-indicators-spinners.R'\n'busy-indicators.R' 'cache-utils.R' 'deprecated.R' 'devmode.R'\n'diagnose.R' 'extended-task.R' 'fileupload.R' 'graph.R'\n'reactives.R' 'reactive-domains.R' 'history.R' 'hooks.R'\n'html-deps.R' 'image-interact-opts.R' 'image-interact.R'\n'imageutils.R' 'input-action.R' 'input-checkbox.R'\n'input-checkboxgroup.R' 'input-date.R' 'input-daterange.R'\n'input-file.R' 'input-numeric.R' 'input-password.R'\n'input-radiobuttons.R' 'input-select.R' 'input-slider.R'\n'input-submit.R' 'input-text.R' 'input-textarea.R'\n'input-utils.R' 'insert-tab.R' 'insert-ui.R' 'jqueryui.R'\n'knitr.R' 'middleware-shiny.R' 'middleware.R' 'timer.R'\n'shiny.R' 'mock-session.R' 'modal.R' 'modules.R'\n'notifications.R' 'otel-attr-srcref.R' 'otel-collect.R'\n'otel-enable.R' 'otel-error.R' 'otel-label.R'\n'otel-reactive-update.R' 'otel-session.R' 'otel-shiny.R'\n'otel-with.R' 'priorityqueue.R' 'progress.R' 'react.R'\n'reexports.R' 'render-cached-plot.R' 'render-plot.R'\n'render-table.R' 'run-url.R' 'runapp.R' 'serializers.R'\n'server-input-handlers.R' 'server-resource-paths.R' 'server.R'\n'shiny-options.R' 'shiny-package.R' 'shinyapp.R' 'shinyui.R'\n'shinywrappers.R' 'showcase.R' 'snapshot.R' 'staticimports.R'\n'tar.R' 'test-export.R' 'test-server.R' 'test.R'\n'update-input.R' 'utils-lang.R' 'utils-tags.R'\n'version_bs_date_picker.R' 'version_ion_range_slider.R'\n'version_jquery.R' 'version_jqueryui.R' 'version_selectize.R'\n'version_strftime.R' 'viewer.R'",
+        "Collate": "'app-handle.R' 'globals.R' 'app-state.R' 'app_template.R'\n'bind-cache.R' 'bind-event.R' 'bookmark-state-local.R'\n'bookmark-state.R' 'bootstrap-deprecated.R'\n'bootstrap-layout.R' 'conditions.R' 'map.R' 'utils.R'\n'bootstrap.R' 'busy-indicators-spinners.R' 'busy-indicators.R'\n'cache-utils.R' 'deprecated.R' 'devmode.R' 'diagnose.R'\n'extended-task.R' 'fileupload.R' 'graph.R' 'reactives.R'\n'reactive-domains.R' 'history.R' 'hooks.R' 'html-deps.R'\n'image-interact-opts.R' 'image-interact.R' 'imageutils.R'\n'input-action.R' 'input-checkbox.R' 'input-checkboxgroup.R'\n'input-date.R' 'input-daterange.R' 'input-file.R'\n'input-numeric.R' 'input-password.R' 'input-radiobuttons.R'\n'input-select.R' 'input-slider.R' 'input-submit.R'\n'input-text.R' 'input-textarea.R' 'input-utils.R'\n'insert-tab.R' 'insert-ui.R' 'jqueryui.R' 'knitr.R'\n'middleware-shiny.R' 'middleware.R' 'timer.R' 'shiny.R'\n'mock-session.R' 'modal.R' 'modules.R' 'notifications.R'\n'otel-attr-srcref.R' 'otel-collect.R' 'otel-enable.R'\n'otel-error.R' 'otel-label.R' 'otel-reactive-update.R'\n'otel-session.R' 'otel-shiny.R' 'otel-with.R' 'priorityqueue.R'\n'progress.R' 'react.R' 'reexports.R' 'render-cached-plot.R'\n'render-plot.R' 'render-table.R' 'run-url.R' 'runapp.R'\n'serializers.R' 'server-input-handlers.R'\n'server-resource-paths.R' 'server.R' 'shiny-options.R'\n'shiny-package.R' 'shinyapp.R' 'shinyui.R' 'shinywrappers.R'\n'showcase.R' 'snapshot.R' 'staticimports.R' 'tar.R'\n'test-export.R' 'test-server.R' 'test.R' 'update-input.R'\n'utils-lang.R' 'utils-tags.R' 'version_bs_date_picker.R'\n'version_ion_range_slider.R' 'version_jquery.R'\n'version_jqueryui.R' 'version_selectize.R' 'version_strftime.R'\n'viewer.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2026-02-19 20:25:10 UTC; cpsievert",
+        "Packaged": "2026-06-18 18:59:37 UTC; cpsievert",
         "Author": "Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Jonathan McPherson [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Prem Nawaz Khan [ctb] (Bootstrap accessibility plugin),\n  Victor Tsaran [ctb] (Bootstrap accessibility plugin),\n  Dennis Lembree [ctb] (Bootstrap accessibility plugin),\n  Srinivasu Chakravarthula [ctb] (Bootstrap accessibility plugin),\n  Cathy O'Connor [ctb] (Bootstrap accessibility plugin),\n  PayPal, Inc [cph] (Bootstrap accessibility plugin),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Salmen Bejaoui [ctb, cph] (selectize-plugin-a11y library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-02-20 09:00:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 22:23:51 UTC; unix"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-21 14:10:08 UTC",
+        "Built": "R 4.6.1; ; 2026-08-21 13:14:29 UTC; unix"
       }
     },
     "shinyWidgets": {
@@ -3012,33 +3073,6 @@
         "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:35 UTC",
         "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-30 14:17:28 UTC; unix"
-      }
-    },
-    "sp": {
-      "Source": "CRAN",
-      "Repository": "https://cloud.r-project.org",
-      "description": {
-        "Package": "sp",
-        "Version": "2.2-1",
-        "Title": "Classes and Methods for Spatial Data",
-        "Authors@R": "c(person(\"Edzer\", \"Pebesma\", role = c(\"aut\", \"cre\"),\n\t\t\t\temail = \"edzer.pebesma@uni-muenster.de\"),\n\t\t\tperson(\"Roger\", \"Bivand\", role = \"aut\",\n            \temail = \"Roger.Bivand@nhh.no\"),\n\t\t\tperson(\"Barry\", \"Rowlingson\", role = \"ctb\"),\n\t\t\tperson(\"Virgilio\", \"Gomez-Rubio\", role = \"ctb\"),\n\t\t\tperson(\"Robert\", \"Hijmans\", role = \"ctb\"),\n\t\t\tperson(\"Michael\", \"Sumner\", role = \"ctb\"),\n\t\t\tperson(\"Don\", \"MacQueen\", role = \"ctb\"),\n\t\t\tperson(\"Jim\", \"Lemon\", role = \"ctb\"),\n                        person(\"Finn\", \"Lindgren\", role = \"ctb\"),\n\t\t\tperson(\"Josh\", \"O'Brien\", role = \"ctb\"),\n\t\t\tperson(\"Joseph\", \"O'Rourke\", role = \"ctb\"),\n            person(\"Patrick\", \"Hausmann\", role = \"ctb\"),\n            person(\"Sebastian\", \"Meyer\", role = \"ctb\"))",
-        "Depends": "R (>= 3.5.0), methods",
-        "Imports": "utils, stats, graphics, grDevices, lattice, grid",
-        "Suggests": "RColorBrewer, gstat, deldir, knitr, maps, mapview, rmarkdown,\nsf, terra, raster",
-        "Description": "Classes and methods for spatial\n  data; the classes document where the spatial location information\n  resides, for 2D or 3D data. Utility functions are provided, e.g. for\n  plotting data as maps, spatial selection, as well as methods for\n  retrieving coordinates, for subsetting, print, summary, etc. From this\n  version, 'rgdal', 'maptools', and 'rgeos' are no longer used at all,\n  see <https://r-spatial.org/r/2023/05/15/evolution4.html> for details.",
-        "License": "GPL (>= 2)",
-        "URL": "https://github.com/edzer/sp/ https://edzer.github.io/sp/",
-        "BugReports": "https://github.com/edzer/sp/issues",
-        "Collate": "bpy.colors.R AAA.R Class-CRS.R CRS-methods.R Class-Spatial.R\nSpatial-methods.R projected.R Class-SpatialPoints.R\nSpatialPoints-methods.R Class-SpatialPointsDataFrame.R\nSpatialPointsDataFrame-methods.R Class-SpatialMultiPoints.R\nSpatialMultiPoints-methods.R\nClass-SpatialMultiPointsDataFrame.R\nSpatialMultiPointsDataFrame-methods.R Class-GridTopology.R\nClass-SpatialGrid.R Class-SpatialGridDataFrame.R\nClass-SpatialLines.R SpatialLines-methods.R\nClass-SpatialLinesDataFrame.R SpatialLinesDataFrame-methods.R\nClass-SpatialPolygons.R Class-SpatialPolygonsDataFrame.R\nSpatialPolygons-methods.R SpatialPolygonsDataFrame-methods.R\nGridTopology-methods.R SpatialGrid-methods.R\nSpatialGridDataFrame-methods.R SpatialPolygons-internals.R\npoint.in.polygon.R SpatialPolygons-displayMethods.R zerodist.R\nimage.R stack.R bubble.R mapasp.R select.spatial.R gridded.R\nasciigrid.R spplot.R over.R spsample.R recenter.R dms.R\ngridlines.R spdists.R rbind.R flipSGDF.R chfids.R loadmeuse.R\ncompassRose.R surfaceArea.R spOptions.R subset.R disaggregate.R\nsp_spat1.R merge.R aggregate.R elide.R sp2Mondrian.R",
-        "VignetteBuilder": "knitr",
-        "NeedsCompilation": "yes",
-        "Packaged": "2026-02-12 22:13:59 UTC; edzer",
-        "Author": "Edzer Pebesma [aut, cre],\n  Roger Bivand [aut],\n  Barry Rowlingson [ctb],\n  Virgilio Gomez-Rubio [ctb],\n  Robert Hijmans [ctb],\n  Michael Sumner [ctb],\n  Don MacQueen [ctb],\n  Jim Lemon [ctb],\n  Finn Lindgren [ctb],\n  Josh O'Brien [ctb],\n  Joseph O'Rourke [ctb],\n  Patrick Hausmann [ctb],\n  Sebastian Meyer [ctb]",
-        "Maintainer": "Edzer Pebesma <edzer.pebesma@uni-muenster.de>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-02-13 10:30:02 UTC",
-        "Encoding": "UTF-8",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 02:34:08 UTC; unix"
       }
     },
     "stringi": {
@@ -3384,7 +3418,7 @@
         "Package": "tinytex",
         "Type": "Package",
         "Title": "Helper Functions to Install and Maintain TeX Live, and Compile\nLaTeX Documents",
-        "Version": "0.59",
+        "Version": "0.60",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(given = \"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\", comment = c(ORCID = \"0000-0003-4474-2498\")),\n  person(\"Devon\", \"Ryan\", role = \"ctb\", email = \"dpryan79@gmail.com\", comment = c(ORCID = \"0000-0002-8549-0971\")),\n  person(\"Ethan\", \"Heinzen\", role = \"ctb\"),\n  person(\"Fernando\", \"Cagua\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Helper functions to install and maintain the 'LaTeX' distribution\n  named 'TinyTeX' (<https://yihui.org/tinytex/>), a lightweight, cross-platform,\n  portable, and easy-to-maintain version of 'TeX Live'. This package also\n  contains helper functions to compile 'LaTeX' documents, and install missing\n  'LaTeX' packages automatically.",
         "Imports": "xfun (>= 0.48)",
@@ -3395,12 +3429,12 @@
         "Encoding": "UTF-8",
         "RoxygenNote": "7.3.3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-03-27 22:21:20 UTC; yihui",
+        "Packaged": "2026-06-15 22:44:20 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>),\n  Posit Software, PBC [cph, fnd],\n  Christophe Dervieux [ctb] (ORCID:\n    <https://orcid.org/0000-0003-4474-2498>),\n  Devon Ryan [ctb] (ORCID: <https://orcid.org/0000-0002-8549-0971>),\n  Ethan Heinzen [ctb],\n  Fernando Cagua [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-03-28 06:10:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-24 03:26:16 UTC; unix"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-06-16 05:10:02 UTC",
+        "Built": "R 4.6.1; ; 2026-08-21 12:59:44 UTC; unix"
       }
     },
     "tzdb": {
@@ -3613,7 +3647,7 @@
       "description": {
         "Package": "withr",
         "Title": "Run Code 'With' Temporarily Modified Global State",
-        "Version": "3.0.2",
+        "Version": "3.0.3",
         "Authors@R": "c(\n    person(\"Jim\", \"Hester\", role = \"aut\"),\n    person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Kirill\", \"Müller\", , \"krlmlr+r@mailbox.org\", role = \"aut\"),\n    person(\"Kevin\", \"Ushey\", , \"kevinushey@gmail.com\", role = \"aut\"),\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\"),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Jennifer\", \"Bryan\", role = \"ctb\"),\n    person(\"Richard\", \"Cotton\", role = \"ctb\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"))\n  )",
         "Description": "A set of functions to run code 'with' safely and temporarily\n    modified global state. Many of these functions were originally a part\n    of the 'devtools' package, this provides a simple package with limited\n    dependencies to provide access to these functions.",
         "License": "MIT + file LICENSE",
@@ -3629,12 +3663,12 @@
         "RoxygenNote": "7.3.2",
         "Collate": "'aaa.R' 'collate.R' 'connection.R' 'db.R' 'defer-exit.R'\n'standalone-defer.R' 'defer.R' 'devices.R' 'local_.R' 'with_.R'\n'dir.R' 'env.R' 'file.R' 'language.R' 'libpaths.R' 'locale.R'\n'makevars.R' 'namespace.R' 'options.R' 'par.R' 'path.R' 'rng.R'\n'seed.R' 'wrap.R' 'sink.R' 'tempfile.R' 'timezone.R'\n'torture.R' 'utils.R' 'with.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2024-10-28 10:58:18 UTC; lionel",
+        "Packaged": "2026-06-17 11:51:00 UTC; lionel",
         "Author": "Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Kirill Müller [aut],\n  Kevin Ushey [aut],\n  Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jennifer Bryan [ctb],\n  Richard Cotton [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-30 14:17:32 UTC; unix"
+        "Date/Publication": "2026-06-19 05:30:02 UTC",
+        "Built": "R 4.6.1; ; 2026-08-21 12:59:39 UTC; unix"
       }
     },
     "wk": {
@@ -3671,7 +3705,7 @@
         "Package": "xfun",
         "Type": "Package",
         "Title": "Supporting Functions for Packages Maintained by 'Yihui Xie'",
-        "Version": "0.57",
+        "Version": "0.60",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\", URL = \"https://yihui.org\")),\n  person(\"Wush\", \"Wu\", role = \"ctb\"),\n  person(\"Daijiang\", \"Li\", role = \"ctb\"),\n  person(\"Xianying\", \"Tan\", role = \"ctb\"),\n  person(\"Salim\", \"Brüggemann\", role = \"ctb\", email = \"salim-b@pm.me\", comment = c(ORCID = \"0000-0002-5329-5987\")),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.",
         "Depends": "R (>= 3.2.0)",
@@ -3681,15 +3715,15 @@
         "URL": "https://github.com/yihui/xfun",
         "BugReports": "https://github.com/yihui/xfun/issues",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
         "VignetteBuilder": "litedown",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-03-19 17:27:02 UTC; yihui",
+        "Packaged": "2026-07-09 05:04:56 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>, URL: https://yihui.org),\n  Wush Wu [ctb],\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Christophe Dervieux [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "RSPM",
-        "Date/Publication": "2026-03-20 16:50:02 UTC",
-        "Built": "R 4.6.0; x86_64-pc-linux-gnu; 2026-04-24 03:10:53 UTC; unix"
+        "Repository": "CRAN",
+        "Date/Publication": "2026-07-09 10:50:02 UTC",
+        "Built": "R 4.6.1; x86_64-pc-linux-gnu; 2026-08-21 12:59:30 UTC; unix"
       }
     },
     "xml2": {
@@ -3779,7 +3813,7 @@
   },
   "files": {
     "app.R": {
-      "checksum": "9ce2765df2af25534573bfb95d3fc177"
+      "checksum": "2f1811773a9c2162e3b326c0f6b1d77c"
     },
     "www/custom.css": {
       "checksum": "47886bbba70d9ba4317274b1dd10a85d"


### PR DESCRIPTION
## Cambio de enfoque: mapa → globo esférico como landing

### Qué cambió
- **Sacado el cloropleta de leaflet** — no era la idea comparar países, solo contar
- **Globo esférico 3D** con `mapgl` (MapLibre GL JS, `projection='globe'`) como landing page
- **Círculos proporcionales** por cantidad de paquetes en cada país (no cloropleta)
- **Click en un país** del globo → filtra el catálogo y salta al tab Catálogo
- **Botón 'Ver todos los paquetes'** para entrar al catálogo completo sin filtro
- **Stats cards** arriba del globo (paquetes, países, categorías)

### Estructura nueva
1. **Tab Mapa (landing)** — globo esférico interactivo + stats + CTA
2. **Tab Catálogo** — filtros + cards de paquetes (igual que antes)

### Dependencias
- `mapgl` reemplaza a `leaflet`
- `sf`, `rnaturalearth`, `rnaturalearthdata` se mantienen
- `geojsonsf`, `sfheaders` (dependencias nuevas de mapgl)
- Manifest regenerado: 132 paquetes

### Test
- ✅ App arranca sin errores desde `app/`
- ✅ 9 puntos en el mapa (países con paquetes)
- ✅ mapgl carga correctamente

Closes #58 (reemplaza el cloropleta del PR #59)