### PR TITLE
fix #63: crash del botón "Ver todos los paquetes"

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -642,12 +642,12 @@ server <- function(input, output, session) {
     updatePickerInput(session, "pais", selected = pais_click)
 
     # Cambiar a la pestaña del catálogo
-    updateNavsetCardTab(session, "tab_principal", selected = "tab_catalogo")
+    nav_select("tab_principal", selected = "tab_catalogo")
   })
 
   # Botón "Ver todos los paquetes" → ir al catálogo sin filtro
   observeEvent(input$ir_catalogo, {
-    updateNavsetCardTab(session, "tab_principal", selected = "tab_catalogo")
+    nav_select("tab_principal", selected = "tab_catalogo")
   })
 
   # --- Datos filtrados reactivos ---


### PR DESCRIPTION
## Fix issue #63

### Causa del crash
 **no existe** en bslib. La función se usaba para cambiar de tab programáticamente, pero al no existir, lanzaba un error que crasheaba la app y mandaba a reload.

### Fix
Reemplazado por  — la función correcta de bslib para actualizar el tab seleccionado en  / .

### Líneas cambiadas


### Flujos afectados
- Click en "Ver todos los paquetes" (botón CTA de la landing)
- Click en un país del globo → filtra catálogo y cambia de tab

Closes #63