### PR TITLE
Agregar paquete: priorcovmatrix

### DIFF
--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -590,3 +590,11 @@ paquetes:
   pais: Uruguay
   categoria: 9
   vigente: true
+- nombre: priorcovmatrix
+  url: https://github.com/nachalca/PriorCovmatrix
+  descripcion: Herramientas para explorar, visualizar y estimar matrices de covarianzas
+    a priori en modelos Bayesianos.
+  autores: Ignacio Alvarez-Castro
+  pais: Uruguay
+  categoria: 5
+  vigente: true

--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -581,3 +581,12 @@ paquetes:
   pais: Chile
   categoria: 5
   vigente: true
+- nombre: esaps
+  url: https://github.com/Nicolas-Schmidt/esaps
+  descripcion: 'Cálculo de indicadores de sistemas electorales y de partidos: volatilidad
+    (Pedersen), fragmentación, desproporcionalidad (Gallagher), número efectivo de
+    partidos (Laakso/Taagepera).'
+  autores: Nicolás Schmidt
+  pais: Uruguay
+  categoria: 9
+  vigente: true


### PR DESCRIPTION
Agrega el paquete `priorcovmatrix` al catálogo.

Cierra #101