### PR TITLE
📦 Agregar: 50 paquetes de Brasil (brverse/IPEA)

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -869,6 +869,20 @@ ui <- page_fluid(
           HTML('<i class="fa-brands fa-bluesky"></i>')
         ),
         tags$a(
+          href = "https://www.instagram.com/estacion.erre/",
+          target = "_blank",
+          title = "Instagram @estacion.erre",
+          class = "footer-social-link",
+          HTML('<i class="fa-brands fa-instagram"></i>')
+        ),
+        tags$a(
+          href = "https://www.linkedin.com/company/estacion-r/",
+          target = "_blank",
+          title = "LinkedIn Estación R",
+          class = "footer-social-link",
+          HTML('<i class="fa-brands fa-linkedin"></i>')
+        ),
+        tags$a(
           href = "mailto:hola@estacion-r.com",
           title = "Escribinos a hola@estacion-r.com",
           class = "footer-social-link",

--- a/app/app.R
+++ b/app/app.R
@@ -883,8 +883,8 @@ ui <- page_fluid(
           HTML('<i class="fa-brands fa-linkedin"></i>')
         ),
         tags$a(
-          href = "mailto:hola@estacion-r.com",
-          title = "Escribinos a hola@estacion-r.com",
+          href = "mailto:pablotiscornia@estacion-r.com",
+          title = "Escribinos a pablotiscornia@estacion-r.com",
           class = "footer-social-link",
           HTML('<i class="fa fa-envelope"></i>')
         )

--- a/app/app.R
+++ b/app/app.R
@@ -277,7 +277,7 @@ ui <- page_fluid(
       /* === Footer === */
       .footer-brand {
         text-align: center;
-        padding: 2rem 1.5rem;
+        padding: 2.5rem 1.5rem 2rem 1.5rem;
         background: #151515;
         color: #FFFFFF;
         margin-top: 4rem;
@@ -293,8 +293,41 @@ ui <- page_fluid(
         font-weight: 500;
       }
       .footer-brand a:hover {
-        color: #447099;
+        color: #EAFF38;
         text-decoration: underline;
+      }
+      .footer-logo-link img {
+        opacity: 0.9;
+        transition: opacity 0.2s ease;
+      }
+      .footer-logo-link:hover img {
+        opacity: 1;
+      }
+      .footer-social-links {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 1.75rem;
+        margin: 1.25rem 0 1.5rem 0;
+        flex-wrap: wrap;
+      }
+      .footer-social-link {
+        color: #EAFF38 !important;
+        font-size: 1.6rem;
+        text-decoration: none !important;
+        display: inline-flex;
+        align-items: center;
+        transition: color 0.2s ease, transform 0.2s ease;
+      }
+      .footer-social-link:hover {
+        color: #FFFFFF !important;
+        transform: translateY(-3px);
+      }
+      .footer-social-link.bsky-link {
+        font-size: 0.95rem;
+        font-weight: 700;
+        gap: 0.3rem;
+        letter-spacing: 0.3px;
       }
       /* === Bandera en esquina superior derecha === */
       .package-flag {
@@ -786,16 +819,66 @@ ui <- page_fluid(
     # Footer
     div(
       class = "footer-brand",
-      tags$img(
-        src = "img/logo_estacion_r_ancho.png",
-        alt = "Estación R",
-        style = "height: 60px; margin-bottom: 20px;"
+
+      # Logo con link a la página de Estación R
+      tags$a(
+        href = "https://estacion-r.com",
+        target = "_blank",
+        class = "footer-logo-link",
+        style = "text-decoration: none;",
+        tags$img(
+          src = "img/logo_estacion_r_ancho.png",
+          alt = "Estación R",
+          style = "height: 60px; margin-bottom: 12px; display: block; margin-left: auto; margin-right: auto;"
+        )
       ),
-      h5(style = "color: #447099; margin-bottom: 20px;",
-         icon("heart"), " Desarrollado por Estación R"),
-      p("Escuela de Datos - Formación en R y Ciencia de Datos"),
+
+      h5(style = "color: #EAFF38; margin-bottom: 4px; font-weight: 700;", "Estación R"),
+      p(style = "color: #C2C2C4; margin-bottom: 0.5rem; font-size: 0.95rem;",
+        "Escuela de Datos · Formación en R y Ciencia de Datos"),
+
+      # Íconos de redes sociales
       div(
-        style = "margin-top: 20px;",
+        class = "footer-social-links",
+        tags$a(
+          href = "https://estacion-r.com",
+          target = "_blank",
+          title = "Sitio web",
+          class = "footer-social-link",
+          HTML('<i class="fa fa-globe"></i>')
+        ),
+        tags$a(
+          href = "https://x.com/estacion_erre",
+          target = "_blank",
+          title = "X / Twitter @estacion_erre",
+          class = "footer-social-link",
+          HTML('<i class="fa-brands fa-x-twitter"></i>')
+        ),
+        tags$a(
+          href = "https://mastodon.social/@pablote",
+          target = "_blank",
+          title = "Mastodon @pablote",
+          class = "footer-social-link",
+          HTML('<i class="fa-brands fa-mastodon"></i>')
+        ),
+        tags$a(
+          href = "https://bsky.app/profile/pablote.bsky.social",
+          target = "_blank",
+          title = "Bluesky",
+          class = "footer-social-link bsky-link",
+          HTML('<i class="fa-brands fa-bluesky"></i>')
+        ),
+        tags$a(
+          href = "mailto:hola@estacion-r.com",
+          title = "Escribinos a hola@estacion-r.com",
+          class = "footer-social-link",
+          HTML('<i class="fa fa-envelope"></i>')
+        )
+      ),
+
+      # Botones de acción
+      div(
+        style = "margin-bottom: 20px;",
         actionButton(
           inputId = "contribuir",
           label = "Proponer un paquete",
@@ -812,7 +895,8 @@ ui <- page_fluid(
           onclick = "window.open('https://github.com/Estacion-R/asombrosos-paquetes-r-latinoamerica', '_blank')"
         )
       ),
-      p(style = "margin-top: 30px; color: #707073; font-size: 0.9rem;",
+
+      p(style = "margin-top: 20px; color: #707073; font-size: 0.85rem;",
         "© 2026 Estación R | Todos los paquetes son propiedad de sus respectivos autores")
     )
   )

--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -1,9 +1,9 @@
 paquetes:
 - nombre: calidad
   url: https://inesscc.github.io/calidad/articles/tutorial.html
-  descripcion: Proporciona indicadores de calidad para estimaciones provenientes
-    de muestreos complejos, con lo cual se busca contribuir a un adecuado
-    uso de los datos publicados por las oficinas de estadísticas de la región
+  descripcion: Proporciona indicadores de calidad para estimaciones provenientes de
+    muestreos complejos, con lo cual se busca contribuir a un adecuado uso de los
+    datos publicados por las oficinas de estadísticas de la región
   autores: Klaus Lehmann, Ricardo Pizarro y Ignacio Agloni
   pais: Chile
   categoria: 1
@@ -11,8 +11,8 @@ paquetes:
   vigente: true
 - nombre: casen
   url: https://github.com/pachadotdev/casen
-  descripcion: Proporciona un conjunto de funciones para realizar estadistica
-    descriptiva e inferencia con el disenio complejo de la encuesta CASEN
+  descripcion: Proporciona un conjunto de funciones para realizar estadistica descriptiva
+    e inferencia con el disenio complejo de la encuesta CASEN
   autores: M. Vargas, Kirill Müller
   pais: Chile
   categoria: 1
@@ -20,8 +20,7 @@ paquetes:
   vigente: true
 - nombre: censobr
   url: https://ipeagit.github.io/censobr/
-  descripcion: Es un paquete para descargar datos del Censo de Población en
-    Brasil
+  descripcion: Es un paquete para descargar datos del Censo de Población en Brasil
   autores: Rafael H. M. Pereira, Ipea - Institute for Applied Economic Research
   pais: Brasil
   categoria: 1
@@ -30,10 +29,10 @@ paquetes:
   hexlogo: https://github.com/ipeaGIT/censobr/blob/main/man/figures/logo.png
 - nombre: DatosAbiertosCEP
   url: https://github.com/CEProduccionXXI/DatosAbiertosCEP
-  descripcion: La librería DatosAbiertosCEP tiene por objetivo colaborar en
-    el acceso y procesamiento de los datos puestos disposición por el Centro
-    de Estudios para la Producción XXI, en la página de Datos Abiertos de
-    la Secretaría de Industria y Desarrollo Productivo del Ministerio de Economía.
+  descripcion: La librería DatosAbiertosCEP tiene por objetivo colaborar en el acceso
+    y procesamiento de los datos puestos disposición por el Centro de Estudios para
+    la Producción XXI, en la página de Datos Abiertos de la Secretaría de Industria
+    y Desarrollo Productivo del Ministerio de Economía.
   autores: Nicolas Sidicaro
   pais: Argentina
   categoria: 1
@@ -68,10 +67,10 @@ paquetes:
   hexlogo: https://github.com/PoliticaArgentina/electorAr/raw/main/man/figures/logo.png
 - nombre: eph
   url: https://holatam.github.io/eph/
-  descripcion: Una caja de herramientas para el procesamiento de datos con
-    la Encuesta Permanente de Hogares (EPH-INDEC)
-  autores: Diego Kozlowski, Pablo Tiscornia, Guido Weksler, Natsumi Shokida,
-    German Rosati y Carolina Pradier
+  descripcion: Una caja de herramientas para el procesamiento de datos con la Encuesta
+    Permanente de Hogares (EPH-INDEC)
+  autores: Diego Kozlowski, Pablo Tiscornia, Guido Weksler, Natsumi Shokida, German
+    Rosati y Carolina Pradier
   pais: Argentina
   categoria: 1
   subcategoria: encuestas
@@ -79,8 +78,8 @@ paquetes:
   hexlogo: https://github.com/holatam/eph/raw/master/man/figures/logo.png
 - nombre: inegiR
   url: https://github.com/Eflores89/inegiR
-  descripcion: Provides functions to download and parse information from INEGI
-    (Official Mexican statistics agency)
+  descripcion: Provides functions to download and parse information from INEGI (Official
+    Mexican statistics agency)
   autores: Eduardo Flores
   pais: México
   categoria: 1
@@ -88,9 +87,9 @@ paquetes:
   vigente: true
 - nombre: occupationcross
   url: https://guidowe.github.io/occupationcross/
-  descripcion: ocupationcross está diseñado para facilitar la compatibilización
-    de los clasificadores nacionales de ocupaciones utilizados en encuestas
-    y censos de distintos países
+  descripcion: ocupationcross está diseñado para facilitar la compatibilización de
+    los clasificadores nacionales de ocupaciones utilizados en encuestas y censos
+    de distintos países
   autores: Guido Weksler y Facundo Lastra
   pais: Argentina
   categoria: 1
@@ -116,9 +115,9 @@ paquetes:
   vigente: true
 - nombre: sfnetworks
   url: https://github.com/luukvdmeer/sfnetworks
-  descripcion: Es un paquete R para el análisis de redes geoespaciales. Conecta
-    las funcionalidades del paquete tidygraph para análisis de redes y el
-    paquete sf para ciencia de datos espaciales
+  descripcion: Es un paquete R para el análisis de redes geoespaciales. Conecta las
+    funcionalidades del paquete tidygraph para análisis de redes y el paquete sf para
+    ciencia de datos espaciales
   autores: Lorena Abad, Lucas van der Meer, Andrea Gilardi, Robin Lovelace
   pais: Ecuador
   categoria: 2
@@ -133,8 +132,8 @@ paquetes:
   vigente: true
 - nombre: cageo
   url: https://manuelspinola.github.io/cageo/
-  descripcion: cageo es un paquete de R que contiene datos geoespaciales de
-    América Central.
+  descripcion: cageo es un paquete de R que contiene datos geoespaciales de América
+    Central.
   autores: Manuel Spínola
   pais: Costa Rica
   categoria: 2
@@ -142,8 +141,8 @@ paquetes:
   hexlogo: https://github.com/ManuelSpinola/cageo/blob/main/man/figures/logo.png
 - nombre: crgeo
   url: https://manuelspinola.github.io/crgeo/
-  descripcion: crgeo es un paquete de R que contiene datos geoespaciales de
-    Costa Rica
+  descripcion: crgeo es un paquete de R que contiene datos geoespaciales de Costa
+    Rica
   autores: Manuel Spínola
   pais: Costa Rica
   categoria: 2
@@ -167,8 +166,8 @@ paquetes:
   hexlogo: https://github.com/ipeaGIT/geobr/raw/master/r-package/man/figures/geobr_logo_y.png?raw=true
 - nombre: geouy
   url: https://github.com/RichDeto/geouy
-  descripcion: geouy is an R package that allows users to easily access official
-    spatial data sets of Uruguay
+  descripcion: geouy is an R package that allows users to easily access official spatial
+    data sets of Uruguay
   autores: Richard Detomasi
   pais: Uruguay
   categoria: 2
@@ -176,9 +175,9 @@ paquetes:
   hexlogo: https://github.com/RichDeto/geouy/raw/master/man/figures/geouy_logo_b.png
 - nombre: mapsPERU
   url: https://github.com/musajajorge/mapsPERU
-  descripcion: mapsPERU es un paquete que proporciona conjuntos de datos con
-    información de los centroides y límites geográficos de las regiones, departamentos,
-    provincias y distritos del Perú
+  descripcion: mapsPERU es un paquete que proporciona conjuntos de datos con información
+    de los centroides y límites geográficos de las regiones, departamentos, provincias
+    y distritos del Perú
   autores: Jorge L. C. Musaja
   pais: Perú
   categoria: 2
@@ -186,8 +185,8 @@ paquetes:
   hexlogo: https://github.com/musajajorge/mapsPERU/raw/main/imgs/hex_mapsPERU.png
 - nombre: RUMBA
   url: https://github.com/bitsandbricks/RUMBA
-  descripcion: Un conjunto de herramientas para el análisis de la Región Urbana
-    Metropolitana de Buenos Aires usando R
+  descripcion: Un conjunto de herramientas para el análisis de la Región Urbana Metropolitana
+    de Buenos Aires usando R
   autores: Antonio Vazquez Brust
   pais: Argentina
   categoria: 2
@@ -195,19 +194,17 @@ paquetes:
   hexlogo: https://github.com/bitsandbricks/RUMBA/raw/master/inst/figures/RUMBA_logo.png
 - nombre: agromet
   url: https://github.com/AgRoMeteorologiaINTA/agromet
-  descripcion: Conjunto de funciones para calcular índices y estadísticos
-    climáticos hidrológicos a partir de datos tidy. Incluye una función para
-    graficar resultados georeferenciados y e información cartográfica
-  autores: Yanina Bellini Saibene, Elio Campitelli, Paola Corrales, Natalia
-    Gattinoni
+  descripcion: Conjunto de funciones para calcular índices y estadísticos climáticos
+    hidrológicos a partir de datos tidy. Incluye una función para graficar resultados
+    georeferenciados y e información cartográfica
+  autores: Yanina Bellini Saibene, Elio Campitelli, Paola Corrales, Natalia Gattinoni
   pais: Argentina
   categoria: 10
   vigente: true
   hexlogo: https://github.com/AgRoMeteorologiaINTA/agromet/raw/master/man/figures/logo.png
 - nombre: ASpli
   url: https://bioconductor.org/packages/release/bioc/html/ASpli.html
-  descripcion: An integrative R package for analysing alternative splicing
-    using RNAseq
+  descripcion: An integrative R package for analysing alternative splicing using RNAseq
   autores: Estefania Mancini, Andrés Rabinovich, Javier Iserte, Marcelo Yanovsky,
     Ariel Chernomoretz
   pais: Argentina
@@ -215,10 +212,10 @@ paquetes:
   vigente: true
 - nombre: CINE
   url: https://github.com/musajajorge/CINE/
-  descripcion: CINE es un paquete que utiliza la lematización de términos
-    educativos para clasificar los programas educativos según la CINE (Clasificación
-    Internacional Normalizada de la Educación) para el Perú publicada por
-    el INEI (Instituto Nacional de Estadística e Informática)
+  descripcion: CINE es un paquete que utiliza la lematización de términos educativos
+    para clasificar los programas educativos según la CINE (Clasificación Internacional
+    Normalizada de la Educación) para el Perú publicada por el INEI (Instituto Nacional
+    de Estadística e Informática)
   autores: Jorge L. C. Musaja
   pais: Perú
   categoria: 8
@@ -226,12 +223,11 @@ paquetes:
   hexlogo: https://github.com/musajajorge/CINE/raw/main/imgs/hex_emblema_CINE.png
 - nombre: concstats
   url: https://docs.ropensci.org/concstats/
-  descripcion: El objetivo del paquete concstats es proporcionar un conjunto
-    de medidas alternativas y/o adicionales para investigadores en ciencias
-    sociales y profesionales en instituciones relacionadas con la competencia
-    de manera regular, con el fin de determinar mejor la estructura de un
-    mercado dado y, por lo tanto, reducir la incertidumbre con respecto a
-    una situación de mercado específica.
+  descripcion: El objetivo del paquete concstats es proporcionar un conjunto de medidas
+    alternativas y/o adicionales para investigadores en ciencias sociales y profesionales
+    en instituciones relacionadas con la competencia de manera regular, con el fin
+    de determinar mejor la estructura de un mercado dado y, por lo tanto, reducir
+    la incertidumbre con respecto a una situación de mercado específica.
   autores: Andreas Schneider
   pais: Paraguay
   categoria: 11
@@ -239,8 +235,8 @@ paquetes:
   hexlogo: https://github.com/ropensci/concstats/blob/master/man/figures/logo.png
 - nombre: metR
   url: https://eliocamp.github.io/metR/
-  descripcion: Funciones útiles y extensiones de ggplot2 para manejar y graficar
-    datos meteorológicos
+  descripcion: Funciones útiles y extensiones de ggplot2 para manejar y graficar datos
+    meteorológicos
   autores: Elio Campitelli
   pais: Argentina
   categoria: 10
@@ -256,8 +252,8 @@ paquetes:
   hexlogo: https://github.com/PoliticaArgentina/opinAr/raw/master/man/figures/logo.png
 - nombre: porArverse
   url: https://politicaargentina.github.io/polArverse/
-  descripcion: Universo de paquetes para trabajar con herramientas y datos
-    de Política Argentina desde R
+  descripcion: Universo de paquetes para trabajar con herramientas y datos de Política
+    Argentina desde R
   autores: Juan Pablo Ruiz Nicolini
   pais: Argentina
   categoria: 9
@@ -265,27 +261,26 @@ paquetes:
   hexlogo: https://camo.githubusercontent.com/7086944caf9b9ba06dd6d90226a81694a9f71c36ccbd2cfd4420d6dc000a880e/68747470733a2f2f706f6c6974696361617267656e74696e612e6769746875622e696f2f706f6c417276657273652f7265666572656e63652f666967757265732f6c6f676f2e706e67
 - nombre: frost
   url: https://github.com/anadiedrichs/frost
-  descripcion: Predicción de la temperatura mínima para la previsión de heladas
-    en la agricultura. Este paquete contiene una recopilación de métodos empíricos
-    utilizados por agricultores e ingenieros agrónomos para predecir la temperatura
-    mínima para detectar un evento de helada.
+  descripcion: Predicción de la temperatura mínima para la previsión de heladas en
+    la agricultura. Este paquete contiene una recopilación de métodos empíricos utilizados
+    por agricultores e ingenieros agrónomos para predecir la temperatura mínima para
+    detectar un evento de helada.
   autores: Ana Laura Diedrichs
   pais: Argentina
   categoria: 10
   vigente: true
 - nombre: tradepolicy
   url: https://github.com/pachadotdev/tradepolicy
-  descripcion: Este paquete proporciona funciones para replicar los resultados
-    originales de Stata del libro An Advanced Guide to Trade Policy Analysis.
+  descripcion: Este paquete proporciona funciones para replicar los resultados originales
+    de Stata del libro An Advanced Guide to Trade Policy Analysis.
   autores: Mauricio Vargas
   pais: Chile
   categoria: 11
   vigente: true
 - nombre: unheadr
   url: https://github.com/luisDVA/unheadr
-  descripcion: El objetivo de unheadr es ayudar a limpiar datos cuando tiene
-    subencabezados incrustados, o cuando los valores se ajustan en varias
-    filas
+  descripcion: El objetivo de unheadr es ayudar a limpiar datos cuando tiene subencabezados
+    incrustados, o cuando los valores se ajustan en varias filas
   autores: Luis Verde Arregoitia
   pais: México
   categoria: 4
@@ -293,8 +288,8 @@ paquetes:
   hexlogo: https://github.com/luisDVA/unheadr/raw/master/man/figures/logosmall.png
 - nombre: sknifedatar
   url: https://rafzamb.github.io/sknifedatar/
-  descripcion: Una extensión del ecosistema modeltime. Con este paquete vas
-    a poder trabajar con modelado y visualización de múltiples series de tiempo
+  descripcion: Una extensión del ecosistema modeltime. Con este paquete vas a poder
+    trabajar con modelado y visualización de múltiples series de tiempo
   autores: Rafael Zambrano y Karina Bartolome
   pais: Argentina
   categoria: 5
@@ -302,9 +297,8 @@ paquetes:
   hexlogo: https://camo.githubusercontent.com/96312cc1dc9e7667393dd53a4945ef4e882c4aced55e6544fe38f3a9e44ffef7/68747470733a2f2f7261667a616d622e6769746875622e696f2f736b6e69666564617461722f7265666572656e63652f666967757265732f6c6f676f2e706e67
 - nombre: funModeling
   url: http://pablo14.github.io/funModeling/
-  descripcion: Este paquete contiene un conjunto de funciones relacionadas
-    con el análisis exploratorio de datos, la preparación de datos y el rendimiento
-    de modelos.
+  descripcion: Este paquete contiene un conjunto de funciones relacionadas con el
+    análisis exploratorio de datos, la preparación de datos y el rendimiento de modelos.
   autores: Pablo Casas
   pais: Argentina
   categoria: 5
@@ -312,8 +306,8 @@ paquetes:
   hexlogo: https://camo.githubusercontent.com/52411c3ab2079010da71b6749d45912eee7890207895dff78ebe91f239e91521/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f64617461736369656e63656865726f65732e636f6d2f696d672f626c6f672f66756e4d6f64656c696e675f6c6f676f5f68712e706e67
 - nombre: rsppfp
   url: https://github.com/melvidoni/rsppfp
-  descripcion: Implementa diferentes algoritmos para transformar grafos en
-    el problema del camino más corto con caminos prohibidos (SPPFP)
+  descripcion: Implementa diferentes algoritmos para transformar grafos en el problema
+    del camino más corto con caminos prohibidos (SPPFP)
   autores: Melina Vidoni
   pais: Argentina
   categoria: 5
@@ -321,9 +315,9 @@ paquetes:
   hexlogo: https://github.com/melvidoni/rsppfp/blob/master/man/figs/logo.png
 - nombre: ggperiodic
   url: https://github.com/eliocamp/ggperiodic
-  descripcion: ggperiodic is an attempt to solve the issue of plotting periodic
-    data in ggplot2. It automatically augments your data to wrap it around
-    to any arbitrary domain
+  descripcion: ggperiodic is an attempt to solve the issue of plotting periodic data
+    in ggplot2. It automatically augments your data to wrap it around to any arbitrary
+    domain
   autores: Elio Campitelli
   pais: Argentina
   categoria: 6
@@ -331,8 +325,8 @@ paquetes:
   hexlogo: https://github.com/eliocamp/ggperiodic/raw/master/man/figures/logo.png
 - nombre: ggnewscale
   url: https://eliocamp.github.io/ggnewscale/
-  descripcion: Paquete que intenta hacer menos doloroso el uso de de múltiples
-    escalas en ggplot2
+  descripcion: Paquete que intenta hacer menos doloroso el uso de de múltiples escalas
+    en ggplot2
   autores: Elio Campitelli
   pais: Argentina
   categoria: 6
@@ -340,8 +334,8 @@ paquetes:
   hexlogo: https://camo.githubusercontent.com/832610c74855a838332287661c9382517654248ce5cc90fb7649000f4538d56c/68747470733a2f2f656c696f63616d702e6769746875622e696f2f67676e65777363616c652f7265666572656e63652f666967757265732f6c6f676f2e706e67
 - nombre: makePalette
   url: https://github.com/musajajorge/makePalette/
-  descripcion: Paquete que contiene funciones que le permiten crear su propia
-    paleta de colores a partir de una imagen, utilizando algoritmos matemáticos
+  descripcion: Paquete que contiene funciones que le permiten crear su propia paleta
+    de colores a partir de una imagen, utilizando algoritmos matemáticos
   autores: Jorge L. C. Musaja
   pais: Perú
   categoria: 6
@@ -349,9 +343,9 @@ paquetes:
   hexlogo: https://github.com/musajajorge/makePalette/raw/main/imgs/hex_emblema_makePalette.png
 - nombre: polArViz
   url: https://politicaargentina.github.io/polArViz/
-  descripcion: Librería auxiliar del polArverse que contiene funciones para
-    visualizaciones que permiten explorar radpidamente la variedad de datos
-    del universo político de Argentina
+  descripcion: Librería auxiliar del polArverse que contiene funciones para visualizaciones
+    que permiten explorar radpidamente la variedad de datos del universo político
+    de Argentina
   autores: Juan Pablo Ruiz Nicolini
   pais: Argentina
   categoria: 6
@@ -367,24 +361,23 @@ paquetes:
   hexlogo: https://github.com/musajajorge/popPyramid/raw/main/imgs/hex_emblema_pyramid.png
 - nombre: datos
   url: https://cienciadedatos.github.io/datos/
-  descripcion: Este paquete provee la traducción al español de conjuntos de
-    datos en inglés originalmente disponibles en otros paquetes de R. Los
-    datos traducidos son los que se utilizan en los ejemplos del libro <a
-    href="https://es.r4ds.hadley.nz/">R para Ciencia de Datos</a>
-  autores: Riva Quiroga, Edgar Ruiz, Mauricio Vargas, Mauro Lepore, Rayna
-    Harris y Daniela Vasquez.
+  descripcion: Este paquete provee la traducción al español de conjuntos de datos
+    en inglés originalmente disponibles en otros paquetes de R. Los datos traducidos
+    son los que se utilizan en los ejemplos del libro <a href="https://es.r4ds.hadley.nz/">R
+    para Ciencia de Datos</a>
+  autores: Riva Quiroga, Edgar Ruiz, Mauricio Vargas, Mauro Lepore, Rayna Harris y
+    Daniela Vasquez.
   pais: Chile
   categoria: 7
   vigente: true
   hexlogo: https://camo.githubusercontent.com/145140f540c1baa91ccd9a16b753e70793283f9e0056c0254e5282b5b4e855d6/68747470733a2f2f6369656e63696164656461746f732e6769746875622e696f2f6461746f732f7265666572656e63652f666967757265732f6c6f676f2e706e67
 - nombre: guaguas
   url: https://rivaquiroga.github.io/guaguas/index.html
-  descripcion: Datos sobre nombres de guaguas (bebés) registrados en Chile
-    entre 1920 y 2021, según el Servicio de Registro Civil e Identificación.
-    Incluye solo los que fueron inscritos como primer nombre. Este dataset
-    permite explorar tendencias en los nombres registrados durante el último
-    siglo y puede utilizarse como fuente de ejemplos para aprender/enseñar
-    a trabajar con datos
+  descripcion: Datos sobre nombres de guaguas (bebés) registrados en Chile entre 1920
+    y 2021, según el Servicio de Registro Civil e Identificación. Incluye solo los
+    que fueron inscritos como primer nombre. Este dataset permite explorar tendencias
+    en los nombres registrados durante el último siglo y puede utilizarse como fuente
+    de ejemplos para aprender/enseñar a trabajar con datos
   autores: Riva Quiroga
   pais: Chile
   categoria: 7
@@ -392,9 +385,9 @@ paquetes:
   hexlogo: https://camo.githubusercontent.com/d911a6c0f699ed2dd77a4181d5fc2db2e21c76805e453d5563b2b36db5659818/68747470733a2f2f72697661717569726f67612e6769746875622e696f2f677561677561732f7265666572656e63652f666967757265732f677561677561732d6865782e706e67
 - nombre: codehover
   url: https://arthurwelle.github.io/codehover/articles/codehover_intro.html
-  descripcion: El objetivo de codehover es facilitar la creación de una tabla
-    HTML con un efecto de desplazamiento (JavaScript/JQuery + CSS) que muestra
-    imágenes justo debajo de dicha tabla de forma sencilla.
+  descripcion: El objetivo de codehover es facilitar la creación de una tabla HTML
+    con un efecto de desplazamiento (JavaScript/JQuery + CSS) que muestra imágenes
+    justo debajo de dicha tabla de forma sencilla.
   autores: Arthur Welle
   pais: Brasil
   categoria: 8
@@ -402,32 +395,31 @@ paquetes:
   hexlogo: https://github.com/arthurwelle/codehover/blob/master/docs/HexSticker/HexSticker.png
 - nombre: metamer
   url: https://eliocamp.github.io/metamer/#metamer
-  descripcion: Implementa el algoritmo propuesto por Matejka & Fitzmaurice
-    (2017) para crear metamers (conjuntos de datos con propiedades estadísticas
-    idénticas pero gráficos muy diferentes) con un esquema de recocido derivado
-    de de Vicente et al
+  descripcion: Implementa el algoritmo propuesto por Matejka & Fitzmaurice (2017)
+    para crear metamers (conjuntos de datos con propiedades estadísticas idénticas
+    pero gráficos muy diferentes) con un esquema de recocido derivado de de Vicente
+    et al
   autores: Elio Campitelli
   pais: Argentina
   categoria: 8
   vigente: true
 - nombre: klassets
   url: https://github.com/jbkunst/klassets
-  descripcion: 'Es una colección de funciones para simular conjuntos de datos
-    para: enseñar cómo funcionan algunos modelos estadísticos y algoritmos
-    de aprendizaje automático, como también ilustrar algunos hechos particulares
-    como la heteroscedasticidad o la paradoja de Simpson e incluso, comparar
-    las predicciones entre modelos, por ejemplo regresión logística vs árbol
-    de decisión vs k-Nearest Neighbours'
+  descripcion: 'Es una colección de funciones para simular conjuntos de datos para:
+    enseñar cómo funcionan algunos modelos estadísticos y algoritmos de aprendizaje
+    automático, como también ilustrar algunos hechos particulares como la heteroscedasticidad
+    o la paradoja de Simpson e incluso, comparar las predicciones entre modelos, por
+    ejemplo regresión logística vs árbol de decisión vs k-Nearest Neighbours'
   autores: Joshua Kunst
   pais: Chile
   categoria: 8
   vigente: true
 - nombre: arcenso
   url: https://soyandrea.github.io/arcenso/
-  descripcion: Proporciona acceso a datos ordenados y curados de los censos
-    nacionales de población de Argentina (1970, 1980, 1991, 2001, 2010 y 2022),
-    facilitando la exploración y reutilización de información histórica censal
-    con herramientas de consulta, validación y visualización interactiva.
+  descripcion: Proporciona acceso a datos ordenados y curados de los censos nacionales
+    de población de Argentina (1970, 1980, 1991, 2001, 2010 y 2022), facilitando la
+    exploración y reutilización de información histórica censal con herramientas de
+    consulta, validación y visualización interactiva.
   autores: Andrea Gomez Vargas, Emanuel Ciardullo
   pais: Argentina
   categoria: 1
@@ -436,10 +428,10 @@ paquetes:
   hexlogo: https://raw.githubusercontent.com/SoyAndrea/arcenso/main/man/figures/logo.png
 - nombre: Argentum
   url: https://thomasartopoulos.github.io/argentum/
-  descripcion: Permite descubrir y leer capas geoespaciales publicadas por
-    organismos públicos argentinos a través de los estándares WFS y WMS del
-    Open Geospatial Consortium, con catálogo cacheado de endpoints, negociación
-    de versiones y descarga vectorial como objetos sf.
+  descripcion: Permite descubrir y leer capas geoespaciales publicadas por organismos
+    públicos argentinos a través de los estándares WFS y WMS del Open Geospatial Consortium,
+    con catálogo cacheado de endpoints, negociación de versiones y descarga vectorial
+    como objetos sf.
   autores: Thomas Artopoulos
   pais: Argentina
   categoria: 2
@@ -447,10 +439,9 @@ paquetes:
   hexlogo: https://raw.githubusercontent.com/thomasartopoulos/argentum/main/man/figures/logo.png
 - nombre: territorial
   url: https://bastianolea.github.io/territorial/
-  descripcion: El objetivo de este paquete es simplificar el análisis de datos
-    territoriales de Chile, facilitando tareas de limpieza y procesamiento
-    de datos que suelen ser necesarias al trabajar con datos de Chile a nivel
-    comunal y regional.
+  descripcion: El objetivo de este paquete es simplificar el análisis de datos territoriales
+    de Chile, facilitando tareas de limpieza y procesamiento de datos que suelen ser
+    necesarias al trabajar con datos de Chile a nivel comunal y regional.
   autores: Bastián Olea Herrera
   pais: Chile
   categoria: 2
@@ -458,17 +449,17 @@ paquetes:
   vigente: true
 - nombre: ismtchile
   url: https://cran.r-project.org/web/packages/ismtchile/index.html
-  descripcion: Facilita el cálculo y distribución del Índice Socio Material
-    Territorial (ISMT), elaborado por el Observatorio de Ciudades UC de Chile.
+  descripcion: Facilita el cálculo y distribución del Índice Socio Material Territorial
+    (ISMT), elaborado por el Observatorio de Ciudades UC de Chile.
   autores: Martín Rosas Araya
   pais: Chile
   categoria: 3
   vigente: true
 - nombre: importinegi
   url: https://github.com/crenteriam/importinegi
-  descripcion: Paquete para descargar y gestionar bases de datos abiertas
-    del INEGI, incluyendo censos, encuestas de hogares y ocupación, y datos
-    geoespaciales de México.
+  descripcion: Paquete para descargar y gestionar bases de datos abiertas del INEGI,
+    incluyendo censos, encuestas de hogares y ocupación, y datos geoespaciales de
+    México.
   autores: crenteriam
   pais: México
   categoria: 1
@@ -476,60 +467,57 @@ paquetes:
   vigente: true
 - nombre: mxmaps
   url: https://www.diegovalle.net/mxmaps/
-  descripcion: Crea mapas coropléticos de México a nivel estatal y municipal,
-    con soporte para mapas interactivos con Leaflet.
+  descripcion: Crea mapas coropléticos de México a nivel estatal y municipal, con
+    soporte para mapas interactivos con Leaflet.
   autores: Diego Valle-Jones
   pais: México
   vigente: true
 - nombre: rsinaica
   url: https://hoyodesmog.diegovalle.net/rsinaica/
-  descripcion: Facilita la descarga de datos de calidad del aire del Sistema
-    Nacional de Información de la Calidad del Aire (SINAICA) de México, con
-    datos de más de cien estaciones de monitoreo.
+  descripcion: Facilita la descarga de datos de calidad del aire del Sistema Nacional
+    de Información de la Calidad del Aire (SINAICA) de México, con datos de más de
+    cien estaciones de monitoreo.
   autores: Diego Valle-Jones
   pais: México
   categoria: 10
   vigente: true
 - nombre: colmaps
   url: https://github.com/nebulae-co/colmaps
-  descripcion: Paquete con datos de límites geográficos actualizados de Colombia
-    (municipios y departamentos) y un wrapper de ggplot2 para crear mapas
-    coropléticos.
+  descripcion: Paquete con datos de límites geográficos actualizados de Colombia (municipios
+    y departamentos) y un wrapper de ggplot2 para crear mapas coropléticos.
   autores: nebulae-co
   pais: Colombia
   categoria: 2
   vigente: true
 - nombre: metasurvey
   url: https://cran.r-project.org/web/packages/metasurvey/index.html
-  descripcion: Pipelines reproducibles para el análisis de encuestas complejas
-    con muestreo complejo. Soporta paneles rotantes con pesos bootstrap y
-    sistema de recetas compartibles entre ediciones.
+  descripcion: Pipelines reproducibles para el análisis de encuestas complejas con
+    muestreo complejo. Soporta paneles rotantes con pesos bootstrap y sistema de recetas
+    compartibles entre ediciones.
   autores: Mauro Loprete
   pais: Argentina
   categoria: 1
   subcategoria: encuestas
 - nombre: sivirep
   url: https://github.com/epiverse-trace/sivirep
-  descripcion: Permite procesar datos del sistema de vigilancia epidemiológica
-    SIVIGILA de Colombia y generar informes epidemiológicos automatizados
-    de salud pública.
+  descripcion: Permite procesar datos del sistema de vigilancia epidemiológica SIVIGILA
+    de Colombia y generar informes epidemiológicos automatizados de salud pública.
   autores: Geraldine Gómez-Millán, Zulma M. Cucunubá, Jennifer A. Mendez-Romero
   pais: Colombia
   categoria: 12
   vigente: true
 - nombre: vaccineff
   url: https://github.com/epiverse-trace/vaccineff
-  descripcion: Herramientas para la estimación de la efectividad vacunal y
-    cálculo de métricas de vacunación a partir de datos de cohorte o de casos
-    y controles.
+  descripcion: Herramientas para la estimación de la efectividad vacunal y cálculo
+    de métricas de vacunación a partir de datos de cohorte o de casos y controles.
   autores: David Santiago Quevedo, Zulma M. Cucunubá
   pais: Colombia
   categoria: 12
   vigente: true
 - nombre: serofoi
   url: https://github.com/epiverse-trace/serofoi
-  descripcion: Estima la fuerza de infección histórica de un patógeno a partir
-    de estudios de seroprevalencia poblacional, usando modelos bayesianos.
+  descripcion: Estima la fuerza de infección histórica de un patógeno a partir de
+    estudios de seroprevalencia poblacional, usando modelos bayesianos.
   autores: N. T. Dominguez, Zulma M. Cucunubá, Ben Lambert
   pais: Colombia
   categoria: 12
@@ -545,52 +533,53 @@ paquetes:
   vigente: true
 - nombre: UnalR
   url: https://github.com/estadisticaun/UnalR
-  descripcion: Simplifica y unifica herramientas de procesamiento estadístico
-    y visualización para la Universidad Nacional de Colombia, con funciones
-    para tablas, gráficos y reportes.
+  descripcion: Simplifica y unifica herramientas de procesamiento estadístico y visualización
+    para la Universidad Nacional de Colombia, con funciones para tablas, gráficos
+    y reportes.
   autores: Jeison Mauricio Alarcon Becerra
   pais: Colombia
   categoria: 5
   vigente: true
 - nombre: rcdo
   url: https://github.com/eliocamp/rcdo
-  descripcion: Wrapper de R para CDO (Climate Data Operators), la herramienta
-    de línea de comandos para operaciones con datos climáticos en formato
-    NetCDF.
+  descripcion: Wrapper de R para CDO (Climate Data Operators), la herramienta de línea
+    de comandos para operaciones con datos climáticos en formato NetCDF.
   autores: Elio Campitelli
   pais: Argentina
   categoria: 10
   vigente: true
 - nombre: SisINTAR
   url: https://github.com/INTA-Suelos/SisINTAR
-  descripcion: Permite procesar y acceder a los datos del Sistema de Información
-    de Suelos del INTA (SISINTA) de Argentina, incluyendo perfiles de suelo
-    georreferenciados.
-  autores: Elio Campitelli, Paola Corrales, Marcos Angelini, Yanina Noemí
-    Bellini Saibene
+  descripcion: Permite procesar y acceder a los datos del Sistema de Información de
+    Suelos del INTA (SISINTA) de Argentina, incluyendo perfiles de suelo georreferenciados.
+  autores: Elio Campitelli, Paola Corrales, Marcos Angelini, Yanina Noemí Bellini
+    Saibene
   pais: Argentina
   categoria: 1
   subcategoria: registros_administrativos
   vigente: true
 - nombre: infiltrodiscR
   url: https://cran.r-project.org/web/packages/infiltrodiscR/index.html
-  descripcion: 'Funciones para modelado de datos del infiltrómetro de minidisco:
-    calcula infiltración acumulada, raíz cuadrada del tiempo y el parámetro
-    A según propiedades físicas del suelo.'
+  descripcion: 'Funciones para modelado de datos del infiltrómetro de minidisco: calcula
+    infiltración acumulada, raíz cuadrada del tiempo y el parámetro A según propiedades
+    físicas del suelo.'
   autores: Carolina V. Giraldo, Sara E. Acevedo, Carlos A. Bonilla
   pais: Chile
   categoria: 5
   vigente: true
-- nombre: "dosr"
-  url: "https://cran.r-project.org/web/packages/dosr/index.html"
-  descripcion: "Herramientas de análisis de encuestas para el Observatorio Social del Ministerio de Desarrollo Social de Chile.
+- nombre: dosr
+  url: https://cran.r-project.org/web/packages/dosr/index.html
+  descripcion: 'Herramientas de análisis de encuestas para el Observatorio Social
+    del Ministerio de Desarrollo Social de Chile.
 
-dosr provee funciones de alto nivel para calcular estimaciones (medias, proporciones, totales, razones y cuantiles) sobre diseños de encuestas complejas (como la CASEN) y generar reportes estandarizados en Excel con clasificación automática de fiabilidad estadística.
-https://gabrielsotomayorl.github.io/dosr/"
-  autores: "Gabriel Sotomayor"
-  pais: "Chile"
+    dosr provee funciones de alto nivel para calcular estimaciones (medias, proporciones,
+    totales, razones y cuantiles) sobre diseños de encuestas complejas (como la CASEN)
+    y generar reportes estandarizados en Excel con clasificación automática de fiabilidad
+    estadística. https://gabrielsotomayorl.github.io/dosr/'
+  autores: Gabriel Sotomayor
+  pais: Chile
   categoria: 1
-  vigente: yes
+  vigente: true
 - nombre: esaps
   url: https://github.com/Nicolas-Schmidt/esaps
   descripcion: 'Cálculo de indicadores de sistemas electorales y de partidos: volatilidad
@@ -600,10 +589,416 @@ https://gabrielsotomayorl.github.io/dosr/"
   pais: Uruguay
   categoria: 9
   vigente: true
-- nombre: "ClustMC"
-  url: "https://cran.r-project.org/web/packages/ClustMC/index.html"
-  descripcion: "Pruebas de comparaciones múltiples basadas en clústeres."
-  autores: "Santiago Garcia Sanchez"
-  pais: "Argentina"
+- nombre: ClustMC
+  url: https://cran.r-project.org/web/packages/ClustMC/index.html
+  descripcion: Pruebas de comparaciones múltiples basadas en clústeres.
+  autores: Santiago Garcia Sanchez
+  pais: Argentina
   categoria: 4
-  vigente: yes
+  vigente: true
+- nombre: ipeadatar
+  url: https://CRAN.R-project.org/package=ipeadatar
+  descripcion: Interfaz para la API de Ipeadata, la base de datos del IPEA con series
+    macroeconómicas, financieras y regionales de Brasil.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: orcamentoBR
+  url: https://CRAN.R-project.org/package=orcamentoBR
+  descripcion: Descarga datos oficiales sobre el presupuesto federal de Brasil.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: deflateBR
+  url: https://github.com/meirelesff/deflatebr/
+  descripcion: Deflacta valores nominales en reales brasileños usando distintos índices
+    de precios (IPCA, IGP-M, IPC, entre otros).
+  autores: Fernando Meireles
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: siconvr
+  url: https://CRAN.R-project.org/package=siconvr
+  descripcion: Accede a datos de la Plataforma +Brasil (SICONV) sobre convenios y
+    transferencias del gobierno federal.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: bacenR
+  url: https://cran.r-project.org/web/packages/bacenR/index.html
+  descripcion: 'Accede a datos del Banco Central de Brasil: IFdata, instituciones
+    activas, balances y actos normativos.'
+  autores: Bruno Thiago Tomio
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: BacenAPI
+  url: https://CRAN.R-project.org/package=BacenAPI
+  descripcion: Recopila datos del Banco Central de Brasil mediante su API pública.
+  autores: Gustavo Barbosa
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: rbcb
+  url: https://wilsonfreitas.github.io/rbcb/
+  descripcion: Interfaz R para los servicios web del Banco Central de Brasil, incluyendo
+    series de tiempo y tasas de cambio.
+  autores: Wilson Freitas
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: brfinance
+  url: https://CRAN.R-project.org/package=brfinance
+  descripcion: Accede a series de tiempo macroeconómicas y financieras de Brasil con
+    salidas ordenadas (tidy).
+  autores: Henrique Cavalieri, Hudson Torrent
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: GetTDData
+  url: https://msperlin.github.io/GetTDData/
+  descripcion: Descarga datos de los bonos del Tesoro Nacional de Brasil (Tesouro
+    Direto).
+  autores: Marcelo S. Perlin
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: bndesr
+  url: https://CRAN.R-project.org/package=bndesr
+  descripcion: Accede a datos del Banco Nacional de Desarrollo Económico y Social
+    (BNDES) de Brasil.
+  autores: Ansgar Wenzelmann
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: BETS
+  url: https://CRAN.R-project.org/package=BETS
+  descripcion: Series de tiempo económicas de Brasil provenientes de distintas fuentes
+    oficiales.
+  autores: Pedro Costa Ferreira, Jonatha Costa, Talitha Speranza
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: cpgfR
+  url: https://CRAN.R-project.org/package=cpgfR
+  descripcion: Consolida información sobre la tarjeta de pagos del gobierno federal
+    brasileño.
+  autores: Paulo Felipe Alencar de Medeiros
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: realestatebr
+  url: https://cran.r-project.org/package=realestatebr
+  descripcion: Consolida datos del mercado inmobiliario brasileño de distintas fuentes
+    (Abecip, Abrainc, BCB, FipeZap, entre otras).
+  autores: Vitor Marinho
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: educabR
+  url: https://CRAN.R-project.org/package=educabR
+  descripcion: Descarga y procesa datos educativos de Brasil del Instituto Nacional
+    de Estudos e Pesquisas Educacionais (INEP).
+  autores: Alan Rodrigues
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: electionsBR
+  url: https://electionsbr.com/novo/
+  descripcion: Funciones para descargar y limpiar datos electorales de Brasil del
+    Tribunal Superior Electoral (TSE).
+  autores: Álvaro Justen, Fernando Meireles, Denisson Silva
+  pais: Brasil
+  categoria: 9
+  vigente: true
+- nombre: speechbr
+  url: https://CRAN.R-project.org/package=speechbr
+  descripcion: Accede a los discursos e información de los legisladores de la Cámara
+    de Diputados de Brasil.
+  autores: Ricardo Freire Patino
+  pais: Brasil
+  categoria: 9
+  vigente: true
+- nombre: agregR
+  url: https://cran.r-project.org/package=agregR
+  descripcion: Agrega encuestas de intención de voto presidencial de Brasil mediante
+    modelos bayesianos de espacio de estados.
+  autores: Jonatan Lajus
+  pais: Brasil
+  categoria: 9
+  vigente: true
+- nombre: enderecobr
+  url: https://ipeagit.github.io/enderecobr
+  descripcion: Estandariza y normaliza direcciones postales brasileñas para facilitar
+    el apareamiento de bases de datos.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 2
+  vigente: true
+- nombre: geocodebr
+  url: https://ipeagit.github.io/geocodebr
+  descripcion: Geolocaliza direcciones brasileñas usando fuentes de datos geoespaciales
+    oficiales.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 2
+  vigente: true
+- nombre: cepR
+  url: https://CRAN.R-project.org/package=cepR
+  descripcion: Busca y valida códigos postales (CEPs) brasileños.
+  autores: Guilherme Jardim Duarte
+  pais: Brasil
+  categoria: 2
+  vigente: true
+- nombre: brclimr
+  url: https://rfsaldanha.github.io/brclimr/
+  descripcion: Obtiene estadísticas zonales de indicadores climáticos para los municipios
+    de Brasil.
+  autores: Raphael Saldanha
+  pais: Brasil
+  categoria: 10
+  vigente: true
+- nombre: BrazilMet
+  url: https://CRAN.R-project.org/package=BrazilMet
+  descripcion: Descarga y procesa datos de estaciones meteorológicas automáticas del
+    INMET de Brasil.
+  autores: Roberto Filgueiras, Luan Periquito Olivares
+  pais: Brasil
+  categoria: 10
+  vigente: true
+- nombre: rmet
+  url: https://cran.r-project.org/package=rmet
+  descripcion: Automatiza la descarga y procesamiento de datos meteorológicos históricos
+    del INMET de Brasil.
+  autores: Frank Willian Souza
+  pais: Brasil
+  categoria: 10
+  vigente: true
+- nombre: florabr
+  url: https://wevertonbio.github.io/florabr/
+  descripcion: Explora la base de datos Flora e Funga do Brasil para consultas taxonómicas
+    y de distribución.
+  autores: Weverton Trindade
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: flora
+  url: https://CRAN.R-project.org/package=flora
+  descripcion: Herramientas para interactuar con la base de datos Flora do Brasil
+    2020.
+  autores: Gustavo Carvalho
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: genderBR
+  url: https://CRAN.R-project.org/package=genderBR
+  descripcion: Predice el género a partir de nombres de pila brasileños usando datos
+    del Censo del IBGE.
+  autores: Fernando Meireles
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: metaphonebr
+  url: https://ipeadata-lab.github.io/metaphonebr/
+  descripcion: Simplifica fonéticamente nombres brasileños con el algoritmo MetafoneBR,
+    diseñado para el apareamiento de bases de datos.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: nomesbr
+  url: https://ipeadata-lab.github.io/nomesbr/
+  descripcion: Limpia y simplifica nombres de personas para facilitar el apareamiento
+    de bases de datos en ausencia de claves únicas.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: SoundexBR
+  url: https://CRAN.R-project.org/package=SoundexBR
+  descripcion: Codificación fonética para el portugués brasileño, útil para la normalización
+    y deduplicación de nombres.
+  autores: Daniel Marcelino
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: brpop
+  url: https://rfsaldanha.github.io/brpop/
+  descripcion: Estimaciones de población brasileña por municipio y grupo de edad.
+  autores: Raphael Saldanha
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: PNADcIBGE
+  url: https://CRAN.R-project.org/package=PNADcIBGE
+  descripcion: Descarga, lee y analiza microdatos de la Encuesta Nacional por Muestreo
+    de Domicilios Continua (PNADC) de Brasil.
+  autores: Gabriel Assunção, Gustavo Toledo
+  pais: Brasil
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+- nombre: PNADCperiods
+  url: https://CRAN.R-project.org/package=PNADCperiods
+  descripcion: Identifica períodos de referencia en los datos de la PNADC de Brasil
+    para facilitar análisis longitudinales.
+  autores: André Sá
+  pais: Brasil
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+- nombre: datazoom.social
+  url: https://CRAN.R-project.org/package=datazoom.social
+  descripcion: Descarga microdatos de la PNADC e incluye algoritmos de identificación
+    de panel para vincular individuos entre oleadas.
+  autores: DataZoom, PUC-Rio
+  pais: Brasil
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+- nombre: microdatasus
+  url: https://rfsaldanha.github.io/microdatasus/
+  descripcion: Descarga y procesa archivos del DataSUS, el sistema de información
+    en salud del Ministerio de Salud de Brasil.
+  autores: Raphael Saldanha
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: PNSIBGE
+  url: https://CRAN.R-project.org/package=PNSIBGE
+  descripcion: Descarga, lee y analiza microdatos de la Encuesta Nacional de Salud
+    (PNS) de Brasil.
+  autores: Gabriel Assunção, Gustavo Toledo
+  pais: Brasil
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+- nombre: COVIDIBGE
+  url: https://CRAN.R-project.org/package=COVIDIBGE
+  descripcion: Descarga, lee y analiza microdatos de la PNAD COVID-19 de Brasil.
+  autores: Gabriel Assunção, Gustavo Toledo
+  pais: Brasil
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+- nombre: BrazilCrime
+  url: https://CRAN.R-project.org/package=BrazilCrime
+  descripcion: Accede a datos de seguridad pública de Brasil del sistema SINESP desde
+    2015.
+  autores: Marcelo Rigon
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: ispdata
+  url: https://CRAN.R-project.org/package=ispdata
+  descripcion: Accede a datos de seguridad pública del Instituto de Seguridad Pública
+    (ISP) de Río de Janeiro.
+  autores: Vitor Marinho
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: flightsbr
+  url: https://ipeagit.github.io/flightsbr
+  descripcion: Descarga datos de vuelos y aeropuertos de Brasil de la Agencia Nacional
+    de Aviación Civil (ANAC).
+  autores: Rafael H. M. Pereira, Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: odbr
+  url: https://hsvab.github.io/odbr/
+  descripcion: Descarga datos de las encuestas origen-destino de Brasil.
+  autores: Haydee Svab
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: aopdata
+  url: https://ipeagit.github.io/aopdata
+  descripcion: Datos del Proyecto de Acceso a Oportunidades del IPEA con métricas
+    de accesibilidad urbana para ciudades brasileñas.
+  autores: Rafael H. M. Pereira, Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: abjData
+  url: https://abjur.github.io/abjData/
+  descripcion: Bases de datos de uso rutinario de la Asociación Brasileña de Jurimetría
+    (ABJ) para estudios cuantitativos del derecho.
+  autores: Associação Brasileira de Jurimetria
+  pais: Brasil
+  categoria: 7
+  vigente: true
+- nombre: aebdata
+  url: https://ipea.github.io/aebdata/
+  descripcion: Accede a datos del Atlas del Estado Brasileño del IPEA sobre instituciones
+    y políticas públicas.
+  autores: Ipea - Institute for Applied Economic Research
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: basedosdados
+  url: https://cran.r-project.org/web/packages/basedosdados/index.html
+  descripcion: Interfaz R para la API de Base dos Dados, plataforma que centraliza
+    datos públicos de Brasil en Google BigQuery.
+  autores: Base dos Dados
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: datazoom.amazonia
+  url: https://cran.r-project.org/package=datazoom.amazonia
+  descripcion: Simplifica el acceso a datos sobre la región amazónica de Brasil desde
+    múltiples fuentes oficiales.
+  autores: DataZoom, PUC-Rio
+  pais: Brasil
+  categoria: 3
+  vigente: true
+- nombre: documentosbr
+  url: https://CRAN.R-project.org/package=documentosbr
+  descripcion: Valida registros administrativos brasileños como CPF, CNPJ y otros
+    documentos de identidad.
+  autores: Tiago Olivoto
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: numbersBR
+  url: https://CRAN.R-project.org/package=numbersBR
+  descripcion: Valida, compara y formatea números de identificación de Brasil (CPF,
+    CNPJ, CEP, entre otros).
+  autores: Wilson Freitas
+  pais: Brasil
+  categoria: 4
+  vigente: true
+- nombre: owdbr
+  url: https://CRAN.R-project.org/package=owdbr
+  descripcion: Datos abiertos sobre bienestar social en Brasil.
+  autores: Vitor Marinho
+  pais: Brasil
+  categoria: 11
+  vigente: true
+- nombre: sidrar
+  url: https://CRAN.R-project.org/package=sidrar
+  descripcion: Interfaz para la API SIDRA del IBGE, el sistema de tablas con datos
+    estadísticos de Brasil.
+  autores: Renato Prado Coelho
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true
+- nombre: ibger
+  url: https://CRAN.R-project.org/package=ibger
+  descripcion: Interfaz amigable con tidyverse para la API de datos agregados del
+    IBGE.
+  autores: Eduardo Bastos
+  pais: Brasil
+  categoria: 1
+  subcategoria: registros_administrativos
+  vigente: true


### PR DESCRIPTION
Agrega **50 paquetes brasileños** al catálogo tomados del repositorio [brverse](https://github.com/ipea/brverse) del IPEA.

## Distribución por categoría

| Categoría | Paquetes |
|-----------|---------|
| 1 - Acceso a datos oficiales | siconvr, educabR, PNADcIBGE, PNADCperiods, datazoom.social, microdatasus, PNSIBGE, COVIDIBGE, brpop, aebdata, basedosdados, sidrar, ibger |
| 2 - Espaciales | enderecobr, geocodebr, cepR |
| 3 - Temáticas específicas | florabr, flora, BrazilCrime, ispdata, flightsbr, odbr, aopdata, datazoom.amazonia |
| 4 - Tratamiento de datos | genderBR, metaphonebr, nomesbr, SoundexBR, documentosbr, numbersBR |
| 7 - Conjunto de datos | abjData |
| 9 - Política y elecciones | electionsBR, speechbr, agregR |
| 10 - Clima y meteorología | brclimr, BrazilMet, rmet |
| 11 - Economía | ipeadatar, orcamentoBR, deflateBR, bacenR, BacenAPI, rbcb, brfinance, GetTDData, bndesr, BETS, cpgfR, realestatebr, owdbr |

## Notas
- censobr y geobr ya estaban en el catálogo → skipped
- basedosdados resuelve el Issue #111 (ahora tiene URL CRAN confirmada)
- Todos con vigente: true
- País: Brasil para todos

Generado con el skill catalogo-r-latam de OpenClaw.