### PR TITLE
feat: agregar bigbang

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -62,7 +62,8 @@ categoria_emoji <- c(
   "9"  = "🗳️",
   "10" = "☁️",
   "11" = "💰",
-  "12" = "🧬"
+  "12" = "🧬",
+  "13" = "🛠️"
 )
 
 subcategoria_label <- c(
@@ -120,7 +121,8 @@ categorias <- c(
   "9"  = "Política y Elecciones",
   "10" = "Clima y Meteorología",
   "11" = "Economía",
-  "12" = "Bioinformática"
+  "12" = "Bioinformática",
+  "13" = "Herramientas de Desarrollo"
 )
 
 # Tema oficial Estación R — spec visual minimalista + paleta oficial

--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -1002,3 +1002,14 @@ paquetes:
   categoria: 1
   subcategoria: registros_administrativos
   vigente: true
+- nombre: bigbang
+  url: https://sebollin.github.io/bigbang/
+  descripcion: Genera metapaquetes al estilo tidyverse a partir de archivos locales
+    de paquetes de R. Produce un único artefacto autocontenido que viaja con sus
+    componentes y los instala en orden de dependencias, pensado para entornos sin
+    conexión o con paquetes internos que no están en ningún repositorio.
+  autores: Sebastián Lucas
+  pais: Uruguay
+  categoria: 13
+  vigente: true
+  hexlogo: https://github.com/sebollin/bigbang/raw/main/man/figures/logo.png


### PR DESCRIPTION
## 📦 bigbang

[bigbang](https://sebollin.github.io/bigbang/) genera metapaquetes al estilo tidyverse a partir de archivos locales de paquetes de R: un único artefacto autocontenido que viaja con sus componentes y los instala en orden de dependencias, pensado para entornos sin conexión o con paquetes internos que no están en ningún repositorio.

### Criterios de inclusión

- ✅ Código abierto: GPL (>= 3)
- ✅ Disponible para instalar: [CRAN](https://CRAN.R-project.org/package=bigbang), [r-universe](https://sebollin.r-universe.dev/bigbang) y [GitHub](https://github.com/sebollin/bigbang)
- ✅ Documentación: [sitio pkgdown](https://sebollin.github.io/bigbang/) y README en español e inglés
- ✅ Desarrollado en Uruguay 🇺🇾

### Categoría nueva propuesta: 13 — Herramientas de Desarrollo 🛠️

No encontré una categoría existente donde encaje: es una herramienta de construcción y empaquetado, no de tratamiento de datos. Siguiendo la invitación del CONTRIBUTING, propongo **Herramientas de Desarrollo**: una categoría para paquetes que ayudan a construir, probar, empaquetar y reproducir proyectos de R, separada de las herramientas de tratamiento y análisis de datos. Agregué el mapeo correspondiente (nombre y emoji) en `app/app.R` para que la entrada renderice bien. Si prefieren otro nombre, número o encuadre, lo ajusto sin problema.

¡Gracias por armar y mantener el catálogo!
