### PR TITLE
📦 Agregar: GeoModels

### DIFF
--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -1131,3 +1131,12 @@ Categoría propuesta: Inteligencia Artificial/LLMs."
   pais: "Uruguay"
   categoria: 4
   vigente: yes
+- nombre: GeoModels
+  url: https://vmoprojs.github.io/GeoModels-page/
+  descripcion: 'Procedimientos para el análisis de datos geoestadísticos gaussianos y no gaussianos: simulación
+    rápida de campos aleatorios, inferencia mediante verosimilitud estándar y verosimilitud compuesta
+    ponderada, y predicción espacial.'
+  autores: Moreno Bevilacqua, Víctor Morales-Oñate, Francisco Cuevas-Pacheco, Christian Caamaño-Carrillo
+  pais: Chile
+  categoria: 5
+  vigente: true


### PR DESCRIPTION
Agrega **GeoModels** al catálogo.

| Campo | Valor |
|-------|-------|
| País | Chile |
| Categoría | 5 — Modelado |
| Autores | Moreno Bevilacqua, Víctor Morales-Oñate, Francisco Cuevas-Pacheco, Christian Caamaño-Carrillo |
| URL | https://vmoprojs.github.io/GeoModels-page/ |

Generado con el skill catalogo-r-latam de OpenClaw.