### PR TITLE
📦 Agregar: mapeAr

### DIFF
--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -1182,3 +1182,12 @@ Categoría propuesta: Inteligencia Artificial/LLMs."
   categoria: 7
   vigente: true
   hexlogo: https://raw.githubusercontent.com/schneiderpy/pRycollection/main/man/figures/logo.png
+- nombre: mapeAr
+  url: https://github.com/dnme-minturdep/mapeAr
+  descripcion: Shiny app para generar y descargar mapas con datos de Argentina a
+    partir de bases propias (puntos, líneas o polígonos), pensada para visualizar
+    información geográfica de turismo.
+  autores: Juan Pablo Ruiz Nicolini
+  pais: Argentina
+  categoria: 2
+  vigente: true


### PR DESCRIPTION
Agrega **mapeAr** al catálogo, cierra el último ítem pendiente del issue #111 (paquetes LatinR 2018-2022).

| Campo | Valor |
|-------|-------|
| País | Argentina |
| Categoría | 2 (Datos Espaciales) |
| Autor | Juan Pablo Ruiz Nicolini |
| URL | https://github.com/dnme-minturdep/mapeAr |

Shiny app de la Dirección Nacional de Mercados y Estadística (Ministerio de Turismo) para generar y descargar mapas con datos propios de Argentina. No tiene DESCRIPTION (no es un paquete R formal) ni logo — se omitió el campo `hexlogo`.

Generado con el skill catalogo-r-latam de OpenClaw.