### PR TITLE
📦 Agregar 4 paquetes propuestos por la comunidad

### DIFF
--- a/data/paquetes.yaml
+++ b/data/paquetes.yaml
@@ -1193,3 +1193,42 @@ Categoría propuesta: Inteligencia Artificial/LLMs."
   pais: Argentina
   categoria: 2
   vigente: true
+- nombre: ENDES.PE
+  url: https://github.com/horaciochacon/ENDES.PE
+  descripcion: Funciones para manipular, extraer y descargar la base de datos de
+    la Encuesta Demográfica y de Salud Familiar (ENDES) de Perú.
+  autores: Horacio Chacón-Torrico
+  pais: Perú
+  categoria: 1
+  subcategoria: encuestas
+  vigente: true
+  hexlogo: https://raw.githubusercontent.com/horaciochacon/ENDES.PE/master/man/figures/logo.png
+- nombre: geoperu
+  url: https://paulesantos.github.io/geoperu/
+  descripcion: Descarga datasets espaciales oficiales de Perú como objetos sf, incluyendo
+    límites administrativos del INEI y áreas naturales protegidas del SERNANP.
+  autores: Paul E. Santos Andrade
+  pais: Perú
+  categoria: 2
+  vigente: true
+  hexlogo: https://raw.githubusercontent.com/paulesantos/geoperu/master/man/figures/logo.png
+- nombre: simulMGF
+  url: https://github.com/mngar/simulMGF
+  descripcion: Simula matrices SNP de genotipos para organismos diploides y rasgos
+    fenotípicos controlados por loci de rasgos cuantitativos, útil para probar modelos
+    de asociación y predicción genómica.
+  autores: Martín Nahuel García
+  pais: Argentina
+  categoria: 12
+  vigente: true
+  hexlogo: https://raw.githubusercontent.com/mngar/simulMGF/master/logo_simulMGF.png
+- nombre: timeSeriesDataSets
+  url: https://lightbluetitan.github.io/timeseriesdatasets_R/index.html
+  descripcion: Colección de datasets de series de tiempo de distintas disciplinas
+    (economía, finanzas, energía, salud y más) para apoyar el análisis de series
+    de tiempo en R.
+  autores: Renzo Caceres Rossi
+  pais: Perú
+  categoria: 7
+  vigente: true
+  hexlogo: https://raw.githubusercontent.com/lightbluetitan/timeseriesdatasets_R/main/man/figures/logo.png


### PR DESCRIPTION
Cierra #46, #49, #50, #51 — paquetes propuestos por la comunidad hace tiempo y nunca procesados.

| Paquete | País | Categoría | Autor |
|---|---|---|---|
| ENDES.PE | Perú | 1 (Datos Oficiales / encuestas) | Horacio Chacón-Torrico |
| geoperu | Perú | 2 (Datos Espaciales) | Paul E. Santos Andrade |
| simulMGF | Argentina | 12 (Bioinformática) | Martín Nahuel García (INTA) |
| timeSeriesDataSets | Perú | 7 (Datasets) | Renzo Caceres Rossi |

Los 4 con hexlogo real verificado (HTTP 200 + image/*). `simulMGF` no está en `man/figures/` estándar — su logo vive en la raíz del repo como `logo_simulMGF.png` (así lo declara su `DESCRIPTION` con `PackageIcon:`).

Closes #46
Closes #49
Closes #50
Closes #51